### PR TITLE
Add wishlist-gift linking, giftlist browsing, and Payout schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# claude code (local config + vendored skills, machine-specific)
+.claude/
+skills-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,3 +75,13 @@ checkout/wallet loop, see `plan-ultraplan.md`.
   line width 80, semicolons, es5 trailing commas. lint-staged runs Prettier then Biome on commit.
 - New server-side logic goes in `actions/<domain>/`; matching validation in `schemas/`.
 - Keep imports organized (Biome `organizeImports` is on).
+- **MongoDB + optional `@unique` fields**: any `String? @unique` field
+  (`Image.giftId`, `Event.url`, `User.email` are existing examples) needs its
+  underlying index converted to `sparse: true` manually. Prisma's schema DSL
+  has no `sparse` option, and `prisma db push` will not create or repair it —
+  a non-sparse unique index only tolerates **one** document missing the
+  field; the second throws `P2002`. Fix via raw Mongo commands
+  (`$runCommandRaw` `dropIndexes` + `createIndexes` with `sparse: true`), and
+  document the manual reindex commands as a comment above the field in
+  `schema.prisma` (copy the pattern from the three existing examples).
+  Apply this immediately whenever a new optional `@unique` field is added.

--- a/actions/common/onboarding.ts
+++ b/actions/common/onboarding.ts
@@ -83,32 +83,36 @@ export const updateProfileStepTwo = async (
     return { error: 'Nombre y apellido son obligatorios.' };
   }
 
-  // Update the primary user's profile
+  // Update the primary user's profile and optionally create the partner's,
+  // atomically — a failure creating the partner must not leave the primary
+  // user advanced to step 3 with the partner's name lost.
   try {
-    await prismaClient.user.update({
-      where: { id: session.user.id },
-      data: {
-        name,
-        lastName,
-        onboardingStep: 3,
-      },
-    });
-
-    // Optionally create a partner's profile if event type is WEDDING
-    if (partnerName && partnerLastName) {
-      await prismaClient.user.create({
+    await prismaClient.$transaction(async tx => {
+      await tx.user.update({
+        where: { id: session.user.id },
         data: {
-          name: partnerName,
-          lastName: partnerLastName,
-          isOnboarded: true,
-          isPrimary: false,
-          isMagicLinkLogin: true,
-          eventId: session.user.eventId,
-          onboardingStep: 5,
-          role: UserType.COUPLE,
+          name,
+          lastName,
+          onboardingStep: 3,
         },
       });
-    }
+
+      // Optionally create a partner's profile if event type is WEDDING
+      if (partnerName && partnerLastName) {
+        await tx.user.create({
+          data: {
+            name: partnerName,
+            lastName: partnerLastName,
+            isOnboarded: true,
+            isPrimary: false,
+            isMagicLinkLogin: true,
+            eventId: session.user.eventId,
+            onboardingStep: 5,
+            role: UserType.COUPLE,
+          },
+        });
+      }
+    });
   } catch (error) {
     console.error('Error updating or creating user:', error);
     return {

--- a/actions/data/category.ts
+++ b/actions/data/category.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import prismaClient from '@/prisma/client';
+
+export async function getCategories() {
+  try {
+    return await prismaClient.category.findMany({
+      orderBy: { name: 'asc' },
+    });
+  } catch (error) {
+    console.error('Error retrieving categories:', error);
+    return [];
+  }
+}

--- a/actions/data/event.ts
+++ b/actions/data/event.ts
@@ -2,7 +2,9 @@
 
 import { getCurrentUser } from '@/actions/get-current-user';
 import type { ErrorResponse } from '@/auth';
+import { EventUrlFormSchema } from '@/schemas/form';
 import { Event, Image as ImageModel, PrismaClient } from '@prisma/client';
+import { revalidatePath } from 'next/cache';
 
 const prismaClient = new PrismaClient();
 
@@ -103,6 +105,44 @@ export const updateEvent = async (
     return {
       error: 'Error updating event',
     };
+  }
+};
+
+export const updateEventUrl = async (eventId: string, url: string) => {
+  const validatedFields = EventUrlFormSchema.safeParse({
+    eventId,
+    eventUrl: url,
+  });
+
+  if (!validatedFields.success) {
+    return {
+      error:
+        validatedFields.error.errors[0]?.message ??
+        'La dirección de tu evento no es válida',
+    };
+  }
+
+  try {
+    const existingEvent = await prismaClient.event.findUnique({
+      where: { url },
+    });
+
+    if (existingEvent && existingEvent.id !== eventId) {
+      return {
+        error: 'Esa dirección ya está en uso, elegí otra.',
+      };
+    }
+
+    const updatedEvent = await prismaClient.event.update({
+      where: { id: eventId },
+      data: { url },
+    });
+
+    revalidatePath('/event-settings');
+    return { success: updatedEvent };
+  } catch (error) {
+    console.error('Error updating event url:', error);
+    return { error: 'Error actualizando la dirección del evento' };
   }
 };
 

--- a/actions/data/event.ts
+++ b/actions/data/event.ts
@@ -122,9 +122,11 @@ export const updateEventUrl = async (eventId: string, url: string) => {
     };
   }
 
+  const normalizedUrl = validatedFields.data.eventUrl;
+
   try {
     const existingEvent = await prismaClient.event.findUnique({
-      where: { url },
+      where: { url: normalizedUrl },
     });
 
     if (existingEvent && existingEvent.id !== eventId) {
@@ -135,7 +137,7 @@ export const updateEventUrl = async (eventId: string, url: string) => {
 
     const updatedEvent = await prismaClient.event.update({
       where: { id: eventId },
-      data: { url },
+      data: { url: normalizedUrl },
     });
 
     revalidatePath('/event-settings');

--- a/actions/data/gift.ts
+++ b/actions/data/gift.ts
@@ -58,6 +58,7 @@ export async function getGifts({
   try {
     return await prismaClient.gift.findMany({
       where: query,
+      include: { image: true },
       orderBy: {
         createdAt: 'desc',
       },
@@ -97,13 +98,23 @@ export async function editGift(
     return { error: 'Datos inválidos, por favor verifica tus datos.' };
   }
 
+  const { imageUrl, ...giftData } = validatedFields.data;
+
   try {
     const gift = await prismaClient.gift.update({
       where: { id: giftId },
       data: {
-        name: validatedFields.data.name,
-        categoryId: validatedFields.data.categoryId,
-        price: validatedFields.data.price,
+        ...giftData,
+        ...(imageUrl
+          ? {
+              image: {
+                upsert: {
+                  create: { url: imageUrl },
+                  update: { url: imageUrl },
+                },
+              },
+            }
+          : {}),
       },
     });
 
@@ -112,10 +123,11 @@ export async function editGift(
     }
 
     revalidatePath('/dashboard');
+    revalidatePath('/wishlist');
     return { giftId: gift.id };
   } catch (error) {
     console.error('Error editing gift:', error);
-    return { error: 'Error al editar el regalo' };
+    return { error: getErrorMessage(error) };
   }
 }
 
@@ -126,10 +138,14 @@ export async function createGift(formData: z.infer<typeof GiftPostSchema>) {
     return { error: 'Datos inválidos, por favor verifica tus datos.' };
   }
 
+  const { imageUrl, sourceGiftId, ...giftData } = validatedFields.data;
+
   try {
     const newGift = await prismaClient.gift.create({
       data: {
-        ...validatedFields.data,
+        ...giftData,
+        ...(sourceGiftId ? { sourceGiftId } : {}),
+        ...(imageUrl ? { image: { create: { url: imageUrl } } } : {}),
       },
     });
 

--- a/actions/data/giftlist.ts
+++ b/actions/data/giftlist.ts
@@ -9,7 +9,7 @@ export async function getGiftlist(giftlistId: string) {
   try {
     const giftlist = await prismaClient.giftlist.findUnique({
       include: {
-        gifts: true,
+        gifts: { include: { image: true } },
       },
       where: {
         id: giftlistId,
@@ -21,7 +21,7 @@ export async function getGiftlist(giftlistId: string) {
     return giftlist;
   } catch (error) {
     console.error('Error retrieving gifts:', error);
-    throw error;
+    return null;
   }
 }
 
@@ -51,7 +51,7 @@ export async function getGiftlists({
     const giftlists = await prismaClient.giftlist.findMany({
       where: query,
       include: {
-        gifts: true,
+        gifts: { include: { image: true } },
       },
     });
 

--- a/actions/data/images.ts
+++ b/actions/data/images.ts
@@ -19,17 +19,14 @@ export async function addImages({
     return { error: 'No image URLs provided' };
   }
 
-  const imageData = imageUrls.map(url => ({
-    eventId,
-    url,
-  }));
-
   try {
-    await prismaClient.image.createMany({
-      data: imageData,
-    });
+    const images = await Promise.all(
+      imageUrls.map(url =>
+        prismaClient.image.create({ data: { eventId, url } })
+      )
+    );
     revalidatePath('/event-details');
-    return { success: true };
+    return { success: true, images };
   } catch (error) {
     console.error('Error uploading event images:', error);
     return { error: 'Error uploading event images' };
@@ -48,12 +45,12 @@ export async function updateImage({
   }
 
   try {
-    await prismaClient.image.update({
+    const image = await prismaClient.image.update({
       where: { id: imageId }, // Target the specific image by ID
       data: { url: imageUrl }, // Update the image URL
     });
     revalidatePath('/event-details');
-    return { success: true };
+    return { success: true, image };
   } catch (error) {
     console.error('Error updating event image:', error);
     console.error('imageId', imageId);

--- a/actions/data/wishlist-gift.ts
+++ b/actions/data/wishlist-gift.ts
@@ -1,0 +1,180 @@
+'use server';
+
+import prismaClient from '@/prisma/client';
+import {
+  WishlistGiftCreateSchema,
+  WishlistGiftDeleteSchema,
+  WishlistGiftEditSchema,
+  WishlistGiftsCreateSchema,
+} from '@/schemas/form';
+import { GetwishlistGiftsParams } from '@/schemas/params';
+import type { Prisma } from '@prisma/client';
+import { revalidatePath } from 'next/cache';
+import type { z } from 'zod';
+import { getErrorMessage } from '../helper';
+
+export async function getWishlistGifts({
+  searchParams,
+}: {
+  searchParams?: z.infer<typeof GetwishlistGiftsParams>;
+}) {
+  const validatedParams = GetwishlistGiftsParams.safeParse(searchParams);
+
+  if (!validatedParams.success) return [];
+
+  const { wishlistId, name, category, page, itemsPerPage } =
+    validatedParams.data;
+  const query: Prisma.WishlistGiftWhereInput = { wishlistId };
+
+  if (name || category) {
+    query.gift = {
+      ...(name ? { name: { contains: name.trim(), mode: 'insensitive' } } : {}),
+      ...(category ? { categoryId: category } : {}),
+    };
+  }
+
+  const skip =
+    page && itemsPerPage ? (Number(page) - 1) * itemsPerPage : undefined;
+  const take = itemsPerPage ? Number(itemsPerPage) : undefined;
+
+  try {
+    return await prismaClient.wishlistGift.findMany({
+      where: query,
+      include: { gift: { include: { image: true } } },
+      orderBy: { createdAt: 'desc' },
+      skip,
+      take,
+    });
+  } catch (error) {
+    console.error('Error retrieving wishlist gifts:', error);
+    return [];
+  }
+}
+
+export async function getWishlistGift(wishlistId: string, giftId: string) {
+  try {
+    return await prismaClient.wishlistGift.findFirst({
+      where: { wishlistId, giftId },
+    });
+  } catch (error) {
+    console.error('Error retrieving wishlist gift:', error);
+    return null;
+  }
+}
+
+export async function createWishlistGift(
+  formData: z.infer<typeof WishlistGiftCreateSchema>
+) {
+  const validatedFields = WishlistGiftCreateSchema.safeParse(formData);
+
+  if (!validatedFields.success) {
+    return { error: 'Datos inválidos, por favor verifica tus datos.' };
+  }
+
+  const { wishlistId, giftId, eventId, isFavoriteGift, isGroupGift } =
+    validatedFields.data;
+
+  const existing = await getWishlistGift(wishlistId, giftId);
+
+  if (existing) {
+    return { error: 'Este regalo ya está en tu lista' };
+  }
+
+  try {
+    const wishlistGift = await prismaClient.wishlistGift.create({
+      data: { wishlistId, giftId, eventId, isFavoriteGift, isGroupGift },
+    });
+
+    revalidatePath('/wishlist');
+    revalidatePath('/gifts');
+    return { wishlistGiftId: wishlistGift.id };
+  } catch (error) {
+    console.error('Error creating wishlist gift:', error);
+    return { error: getErrorMessage(error) };
+  }
+}
+
+export async function createWishlistGifts(
+  formData: z.infer<typeof WishlistGiftsCreateSchema>
+) {
+  const validatedFields = WishlistGiftsCreateSchema.safeParse(formData);
+
+  if (!validatedFields.success) {
+    return { error: 'Datos inválidos, por favor verifica tus datos.' };
+  }
+
+  const { wishlistId, giftIds, eventId } = validatedFields.data;
+
+  try {
+    const existing = await prismaClient.wishlistGift.findMany({
+      where: { wishlistId, giftId: { in: giftIds } },
+      select: { giftId: true },
+    });
+    const existingGiftIds = new Set(existing.map(wishlistGift => wishlistGift.giftId));
+    const newGiftIds = giftIds.filter(giftId => !existingGiftIds.has(giftId));
+
+    if (newGiftIds.length > 0) {
+      await prismaClient.wishlistGift.createMany({
+        data: newGiftIds.map(giftId => ({ wishlistId, giftId, eventId })),
+      });
+    }
+
+    revalidatePath('/wishlist');
+    revalidatePath('/gifts');
+    return { success: true };
+  } catch (error) {
+    console.error('Error creating wishlist gifts:', error);
+    return { error: getErrorMessage(error) };
+  }
+}
+
+export async function editWishlistGift(
+  formData: z.infer<typeof WishlistGiftEditSchema>
+) {
+  const validatedFields = WishlistGiftEditSchema.safeParse(formData);
+
+  if (!validatedFields.success) {
+    return { error: 'Datos inválidos, por favor verifica tus datos.' };
+  }
+
+  const { wishlistGiftId, giftId, isFavoriteGift, isGroupGift } =
+    validatedFields.data;
+
+  try {
+    await prismaClient.wishlistGift.update({
+      where: { id: wishlistGiftId },
+      data: { giftId, isFavoriteGift, isGroupGift },
+    });
+
+    revalidatePath('/wishlist');
+    return { success: true };
+  } catch (error) {
+    console.error('Error editing wishlist gift:', error);
+    return { error: getErrorMessage(error) };
+  }
+}
+
+export async function deleteWishlistGift(
+  formData: z.infer<typeof WishlistGiftDeleteSchema>
+) {
+  const validatedFields = WishlistGiftDeleteSchema.safeParse(formData);
+
+  if (!validatedFields.success) {
+    return { error: 'Datos inválidos, por favor verifica tus datos.' };
+  }
+
+  const { wishlistId, giftId } = validatedFields.data;
+
+  try {
+    await prismaClient.wishlistGift.deleteMany({
+      where: { wishlistId, giftId },
+    });
+
+    revalidatePath('/wishlist');
+    revalidatePath('/gifts');
+    return { success: true };
+  } catch (error) {
+    console.error('Error deleting wishlist gift:', error);
+    return { error: getErrorMessage(error) };
+  }
+}

--- a/app/(default)/gifts/lists/[giftlistId]/page.tsx
+++ b/app/(default)/gifts/lists/[giftlistId]/page.tsx
@@ -1,0 +1,140 @@
+import { redirect } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
+import { getGiftlist } from '@/actions/data/giftlist';
+import { getEvent } from '@/actions/data/event';
+import { getWishlistGifts } from '@/actions/data/wishlist-gift';
+import { getCategories } from '@/actions/data/category';
+import AddGiftlistToWishlistButton from '@/components/dashboard/add-giftlist-to-wishlist-button';
+import GiftTypeBadge from '@/components/dashboard/gift-type-badge';
+import GiftAddedBadge from '@/components/dashboard/gift-added-badge';
+import { IoGiftOutline } from 'react-icons/io5';
+import { ChevronLeft } from 'lucide-react';
+
+export default async function GiftlistDetailPage({
+  params,
+}: {
+  params: { giftlistId: string };
+}) {
+  const event = await getEvent();
+
+  if (!event || 'error' in event) {
+    return <div>Error</div>;
+  }
+
+  const [giftlist, wishlistGifts, categories] = await Promise.all([
+    getGiftlist(params.giftlistId),
+    getWishlistGifts({ searchParams: { wishlistId: event.wishlistId } }),
+    getCategories(),
+  ]);
+
+  if (!giftlist) {
+    redirect('/gifts');
+  }
+
+  const categoryNameById = new Map(
+    categories.map(category => [category.id, category.name])
+  );
+  const wishlistGiftIds = new Set(
+    wishlistGifts.map(wishlistGift => wishlistGift.giftId)
+  );
+  const giftIds = giftlist.gifts.map(gift => gift.id);
+  const allInWishlist =
+    giftIds.length > 0 && giftIds.every(giftId => wishlistGiftIds.has(giftId));
+  const totalPrice = giftlist.gifts.reduce(
+    (sum, gift) => sum + Number(gift.price || 0),
+    0
+  );
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Link
+          href="/gifts"
+          className="flex items-center text-sm text-gray-600 hover:text-gray-900 mb-2 gap-2"
+        >
+          <ChevronLeft className="w-4 h-4" />
+          Volver
+        </Link>
+
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
+          <div>
+            <h1 className="text-3xl font-black">{giftlist.name}</h1>
+            <p className="text-textTertiary mt-2">
+              Productos: {giftlist.gifts.length} - En efectivo: Gs.{' '}
+              {totalPrice.toLocaleString('es-PY')}
+            </p>
+          </div>
+          <AddGiftlistToWishlistButton
+            eventId={event.id}
+            wishlistId={event.wishlistId}
+            giftIds={giftIds}
+            allInWishlist={allInWishlist}
+          />
+        </div>
+
+        <div className="bg-white rounded-lg">
+          <div className="grid grid-cols-1 gap-4">
+            <div className="hidden sm:grid sm:grid-cols-12 gap-4 px-4 py-3 bg-gray-50 rounded-t-lg text-sm font-medium text-gray-600">
+              <div className="col-span-5">Nombre y categoría</div>
+              <div className="col-span-2">Tipo</div>
+              <div className="col-span-2">Precio</div>
+              <div className="col-span-3">Estado</div>
+            </div>
+
+            {giftlist.gifts.length === 0 ? (
+              <div className="text-center py-12 text-gray-500">
+                Este paquete no tiene regalos
+              </div>
+            ) : (
+              giftlist.gifts.map(gift => {
+                const isInWishlist = wishlistGiftIds.has(gift.id);
+
+                return (
+                  <div
+                    key={gift.id}
+                    className="grid grid-cols-1 sm:grid-cols-12 gap-4 px-4 py-4 border-b border-gray-100 hover:bg-gray-50 items-center"
+                  >
+                    <div className="col-span-5 flex items-center gap-3">
+                      <div className="w-12 h-12 bg-gray-200 rounded flex items-center justify-center overflow-hidden shrink-0">
+                        {gift.image?.url ? (
+                          <Image
+                            src={gift.image.url}
+                            alt={gift.name}
+                            className="w-full h-full object-cover"
+                            width={48}
+                            height={48}
+                          />
+                        ) : (
+                          <IoGiftOutline className="text-2xl text-gray-400" />
+                        )}
+                      </div>
+                      <div>
+                        <p className="font-medium">{gift.name}</p>
+                        <p className="text-sm text-gray-500">
+                          {categoryNameById.get(gift.categoryId) ??
+                            'Sin categoría'}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="col-span-2">
+                      <GiftTypeBadge isGroupGift={false} />
+                    </div>
+                    <div className="col-span-2">
+                      <span className="text-sm">
+                        Gs.{Number(gift.price).toLocaleString('es-PY')}
+                      </span>
+                    </div>
+                    <div className="col-span-3">
+                      <GiftAddedBadge isInWishlist={isInWishlist} />
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(default)/gifts/lists/page.tsx
+++ b/app/(default)/gifts/lists/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function GiftlistsIndexPage() {
+  redirect('/gifts');
+}

--- a/app/(default)/gifts/page.tsx
+++ b/app/(default)/gifts/page.tsx
@@ -1,10 +1,18 @@
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { getGifts } from '@/actions/data/gift';
 import { getGiftlists } from '@/actions/data/giftlist';
-import { IoAdd, IoSearchOutline, IoGiftOutline } from 'react-icons/io5';
+import { getEvent } from '@/actions/data/event';
+import { getWishlistGifts } from '@/actions/data/wishlist-gift';
+import { getCategories } from '@/actions/data/category';
+import GiftRow from '@/components/dashboard/gift-row';
+import GiftsFilterBar from '@/components/dashboard/gifts-filter-bar';
+import CreateGiftDialog from '@/components/dialog/create-gift-dialog';
+import { IoGiftOutline } from 'react-icons/io5';
 import { PiPackageFill } from 'react-icons/pi';
+import { ChevronLeft } from 'lucide-react';
+import Image from 'next/image';
 import Link from 'next/link';
 
 export default async function GiftsPage({
@@ -12,31 +20,48 @@ export default async function GiftsPage({
 }: {
   searchParams?: { [key: string]: string | string[] | undefined };
 }) {
-  const gifts = await getGifts({ searchParams });
-  const giftlists = await getGiftlists({ searchParams });
+  const event = await getEvent();
+
+  if (!event || 'error' in event) {
+    return <div>Error</div>;
+  }
+
+  const [gifts, giftlists, wishlistGifts, categories] = await Promise.all([
+    getGifts({ searchParams }),
+    getGiftlists({ searchParams }),
+    getWishlistGifts({ searchParams: { wishlistId: event.wishlistId } }),
+    getCategories(),
+  ]);
+
+  const wishlistGiftIds = new Set(
+    wishlistGifts.map(wishlistGift => wishlistGift.giftId)
+  );
 
   return (
     <div className="min-h-screen bg-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex items-center justify-between mb-8">
           <div>
-            <Link href="/wishlist" className="text-sm text-gray-600 hover:text-gray-900 mb-2 inline-block">
-              ← Volver
+            <Link href="/wishlist" className="flex items-center text-sm text-gray-600 hover:text-gray-900 mb-2 gap-2">
+              <ChevronLeft className="w-4 h-4" />
+              Volver
             </Link>
             <h1 className="text-3xl font-black">Agregar regalos</h1>
             <p className="text-textTertiary mt-2">
-              Lorem ipsum dolor asit meLorem ipsum dolor asit mett
+              Explorá los regalos disponibles y agregalos a tu lista, o creá
+              los tuyos propios.
             </p>
           </div>
-          <Button variant="success" className="gap-2">
-            Crear regalo
-            <IoAdd className="text-2xl" />
-          </Button>
+          <CreateGiftDialog
+            eventId={event.id}
+            wishlistId={event.wishlistId}
+            categories={categories}
+          />
         </div>
 
         <Tabs defaultValue="todos" className="w-full">
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
-            <TabsList>
+            <TabsList className='gap-3'>
               <TabsTrigger value="todos" className="gap-2">
                 <IoGiftOutline className="text-lg" />
                 Todos los productos
@@ -47,19 +72,7 @@ export default async function GiftsPage({
               </TabsTrigger>
             </TabsList>
 
-            <div className="flex items-center gap-3 w-full sm:w-auto">
-              <div className="relative flex-1 sm:w-64">
-                <IoSearchOutline className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
-                <Input
-                  type="text"
-                  placeholder="Regalo"
-                  className="pl-10"
-                />
-              </div>
-              <select className="h-10 rounded-md border border-input bg-white px-3 py-2 text-sm">
-                <option>Categoría</option>
-              </select>
-            </div>
+            <GiftsFilterBar categories={categories} />
           </div>
 
           <TabsContent value="todos" className="mt-6">
@@ -79,43 +92,14 @@ export default async function GiftsPage({
                   </div>
                 ) : (
                   gifts.map((gift) => (
-                    <div
+                    <GiftRow
                       key={gift.id}
-                      className="grid grid-cols-1 sm:grid-cols-12 gap-4 px-4 py-4 border-b border-gray-100 hover:bg-gray-50 items-center"
-                    >
-                      <div className="col-span-4 flex items-center gap-3">
-                        <div className="w-12 h-12 bg-gray-200 rounded flex items-center justify-center">
-                          <IoGiftOutline className="text-2xl text-gray-400" />
-                        </div>
-                        <div>
-                          <p className="font-medium">{gift.name}</p>
-                          <p className="text-sm text-gray-500">{gift.categoryId}</p>
-                        </div>
-                      </div>
-                      <div className="col-span-2 flex items-center gap-2">
-                        <IoGiftOutline className="text-sm" />
-                        <span className="text-sm">
-                          {gift.giftlistId ? 'Regalo Grupal' : 'Regalo Individual'}
-                        </span>
-                      </div>
-                      <div className="col-span-2">
-                        <span className="text-sm">
-                          {gift.price ? `Gs.${Number(gift.price).toLocaleString()}` : 'Sin límite'}
-                        </span>
-                      </div>
-                      <div className="col-span-2">
-                        <div className="flex items-center gap-2 text-sm">
-                          <IoSearchOutline className="text-gray-400" />
-                          <span>No agregado</span>
-                        </div>
-                      </div>
-                      <div className="col-span-2 flex justify-end">
-                        <Button variant="success" size="sm" className="gap-2">
-                          <IoAdd />
-                          Agregar regalo
-                        </Button>
-                      </div>
-                    </div>
+                      gift={gift}
+                      eventId={event.id}
+                      wishlistId={event.wishlistId}
+                      categories={categories}
+                      isInWishlist={wishlistGiftIds.has(gift.id)}
+                    />
                   ))
                 )}
               </div>
@@ -135,26 +119,38 @@ export default async function GiftsPage({
                     className="border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow"
                   >
                     <div className="grid grid-cols-2 gap-2 mb-4">
-                      {giftlist.gifts.slice(0, 4).map((gift, idx) => (
+                      {giftlist.gifts.slice(0, 4).map((gift) => (
                         <div
-                          key={idx}
-                          className="aspect-square bg-gray-200 rounded flex items-center justify-center"
+                          key={gift.id}
+                          className="aspect-square bg-gray-200 rounded flex items-center justify-center overflow-hidden"
                         >
-                          <IoGiftOutline className="text-3xl text-gray-400" />
+                          {gift.image?.url ? (
+                            <Image
+                              src={gift.image.url}
+                              alt={gift.name}
+                              className="w-full h-full object-cover"
+                              width={200}
+                              height={200}
+                            />
+                          ) : (
+                            <IoGiftOutline className="text-3xl text-gray-400" />
+                          )}
                         </div>
                       ))}
                     </div>
-                    <div className="mb-2">
-                      <p className="text-sm text-gray-500">
+                    <div className="flex flex-col gap-2 mb-4">
+                      <Badge className="w-fit bg-gray100 text-textTertiary border-transparent">
                         {giftlist.gifts.length} productos
-                      </p>
-                      <h3 className="text-lg font-bold mt-1">{giftlist.name}</h3>
-                      <p className="text-lg font-semibold mt-1">
+                      </Badge>
+                      <h3 className="text-lg font-bold">{giftlist.name}</h3>
+                      <p className="text-lg font-semibold">
                         Gs. {giftlist.gifts.reduce((sum, gift) => sum + Number(gift.price || 0), 0).toLocaleString()}
                       </p>
                     </div>
-                    <Button variant="outline" className="w-full mt-4">
-                      Ver paquete
+                    <Button variant="outline" asChild>
+                      <Link href={`/gifts/lists/${giftlist.id}`}>
+                        Ver paquete
+                      </Link>
                     </Button>
                   </div>
                 ))

--- a/app/(default)/gifts/page.tsx
+++ b/app/(default)/gifts/page.tsx
@@ -42,14 +42,17 @@ export default async function GiftsPage({
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex items-center justify-between mb-8">
           <div>
-            <Link href="/wishlist" className="flex items-center text-sm text-gray-600 hover:text-gray-900 mb-2 gap-2">
+            <Link
+              href="/wishlist"
+              className="flex items-center text-sm text-gray-600 hover:text-gray-900 mb-2 gap-2"
+            >
               <ChevronLeft className="w-4 h-4" />
               Volver
             </Link>
             <h1 className="text-3xl font-black">Agregar regalos</h1>
             <p className="text-textTertiary mt-2">
-              Explorá los regalos disponibles y agregalos a tu lista, o creá
-              los tuyos propios.
+              Explorá los regalos disponibles y agregalos a tu lista, o creá los
+              tuyos propios.
             </p>
           </div>
           <CreateGiftDialog
@@ -61,7 +64,7 @@ export default async function GiftsPage({
 
         <Tabs defaultValue="todos" className="w-full">
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
-            <TabsList className='gap-3'>
+            <TabsList className="gap-3">
               <TabsTrigger value="todos" className="gap-2">
                 <IoGiftOutline className="text-lg" />
                 Todos los productos
@@ -91,7 +94,7 @@ export default async function GiftsPage({
                     No se encontraron regalos
                   </div>
                 ) : (
-                  gifts.map((gift) => (
+                  gifts.map(gift => (
                     <GiftRow
                       key={gift.id}
                       gift={gift}
@@ -113,13 +116,13 @@ export default async function GiftsPage({
                   No se encontraron listas predefinidas
                 </div>
               ) : (
-                giftlists.map((giftlist) => (
+                giftlists.map(giftlist => (
                   <div
                     key={giftlist.id}
-                    className="border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow"
+                    className="border border-gray-200 rounded-lg p-6 hover:shadow-sm transition-shadow"
                   >
                     <div className="grid grid-cols-2 gap-2 mb-4">
-                      {giftlist.gifts.slice(0, 4).map((gift) => (
+                      {giftlist.gifts.slice(0, 4).map(gift => (
                         <div
                           key={gift.id}
                           className="aspect-square bg-gray-200 rounded flex items-center justify-center overflow-hidden"
@@ -144,10 +147,21 @@ export default async function GiftsPage({
                       </Badge>
                       <h3 className="text-lg font-bold">{giftlist.name}</h3>
                       <p className="text-lg font-semibold">
-                        Gs. {giftlist.gifts.reduce((sum, gift) => sum + Number(gift.price || 0), 0).toLocaleString()}
+                        Gs.{' '}
+                        {giftlist.gifts
+                          .reduce(
+                            (sum, gift) => sum + Number(gift.price || 0),
+                            0
+                          )
+                          .toLocaleString()}
                       </p>
                     </div>
-                    <Button variant="outline" asChild>
+                    <Button
+                      className="hover:bg-gray100 transition-colors"
+                      variant="outline"
+                      asChild
+                      size="lg"
+                    >
                       <Link href={`/gifts/lists/${giftlist.id}`}>
                         Ver paquete
                       </Link>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { IoGiftOutline } from 'react-icons/io5';
+import { Button } from '@/components/ui/button';
+import EmptyState from '@/components/common/empty-state';
+import wedinIcon from '@/public/assets/w-icon.svg';
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col gap-8 justify-center items-center min-h-screen bg-white">
+      <Link href="/" className="flex gap-1 items-center text-wedinMain">
+        <Image src={wedinIcon} alt="wedin icon" width={46} />
+        <h1 className="text-xl font-bold">wedin</h1>
+      </Link>
+
+      <EmptyState
+        icon={<IoGiftOutline className="text-6xl" />}
+        title="Página no encontrada"
+        description="La página que buscás no existe o fue movida."
+        action={
+          <Link href="/">
+            <Button variant="success">Volver al inicio</Button>
+          </Link>
+        }
+      />
+    </div>
+  );
+}

--- a/components/dashboard/add-giftlist-to-wishlist-button.tsx
+++ b/components/dashboard/add-giftlist-to-wishlist-button.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { useWishlistGift } from '@/hooks/dashboard/use-wishlist-gift';
+import { Loader2 } from 'lucide-react';
+import { IoCheckmarkCircle } from 'react-icons/io5';
+
+type AddGiftlistToWishlistButtonProps = {
+  eventId: string;
+  wishlistId: string;
+  giftIds: string[];
+  allInWishlist: boolean;
+};
+
+export default function AddGiftlistToWishlistButton({
+  eventId,
+  wishlistId,
+  giftIds,
+  allInWishlist,
+}: AddGiftlistToWishlistButtonProps) {
+  const { loading, addAllToWishlist } = useWishlistGift();
+
+  if (allInWishlist) {
+    return (
+      <Button variant="outline" className="gap-2" disabled>
+        <IoCheckmarkCircle className="text-success" />
+        Paquete agregado
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant="success"
+      className="gap-2"
+      disabled={loading || giftIds.length === 0}
+      onClick={() => addAllToWishlist({ wishlistId, eventId, giftIds })}
+    >
+      Agregar paquete completo
+      {loading && <Loader2 className="w-4 h-4 animate-spin" />}
+    </Button>
+  );
+}

--- a/components/dashboard/add-to-wishlist-button.tsx
+++ b/components/dashboard/add-to-wishlist-button.tsx
@@ -1,0 +1,11 @@
+import { Button } from '@/components/ui/button';
+import { IoAdd } from 'react-icons/io5';
+
+export default function AddToWishlistButton() {
+  return (
+    <Button variant="success" size="sm" className="gap-2" type="button">
+      <IoAdd />
+      Agregar regalo
+    </Button>
+  );
+}

--- a/components/dashboard/dashboard-bank-details.tsx
+++ b/components/dashboard/dashboard-bank-details.tsx
@@ -18,7 +18,7 @@ export default async function DashboardBankDetails() {
 
   return (
     <section className="w-full h-full flex flex-col gap-12 sm:gap-8 justify-start items-center">
-      <div className="w-full flex flex-col gap-4 border-b border-gray-200 pb-6">
+      <div className="w-full flex flex-col gap-2 border-b border-gray-200 pb-6">
         <h1 className="text-2xl font-black">Configuración Bancaria</h1>
         <p className="text-textTertiary">
           Define los detalles importantes de tu evento: Configuración Bancaria.

--- a/components/dashboard/dashboard-event-details.tsx
+++ b/components/dashboard/dashboard-event-details.tsx
@@ -15,7 +15,7 @@ export default async function DashboardEventDetails() {
 
   return (
     <section className="w-full h-full flex flex-col gap-12 sm:gap-8 justify-start items-center">
-      <div className="w-full flex flex-col gap-4 border-b border-gray-200 pb-6">
+      <div className="w-full flex flex-col gap-2 border-b border-gray-200 pb-6">
         <h1 className="text-2xl font-black">Presentación</h1>
         <p className="text-textTertiary">
           Haz que tu evento brille: sube fotos y cuenta de qué se trata, para

--- a/components/dashboard/dashboard-event-settings.tsx
+++ b/components/dashboard/dashboard-event-settings.tsx
@@ -27,7 +27,7 @@ export default async function DashboardEventSettings() {
 
   return (
     <section className="w-full h-full flex flex-col gap-12 sm:gap-8 justify-start items-center">
-      <div className="w-full flex flex-col gap-4 border-b border-gray-200 pb-6">
+      <div className="w-full flex flex-col gap-2 border-b border-gray-200 pb-6">
         <h1 className="text-2xl font-black">Configuración General</h1>
         <p className="text-textTertiary">
           Define los detalles importantes de tu evento: establece la fecha,

--- a/components/dashboard/dashboard-home.tsx
+++ b/components/dashboard/dashboard-home.tsx
@@ -7,7 +7,7 @@ import { IoEyeOutline } from 'react-icons/io5';
 export default function DashboardHome() {
   return (
     <section className="w-full h-full flex flex-col justify-start items-center gap-12">
-      <div className="w-full flex flex-col gap-4 border-b border-gray-200 pb-6">
+      <div className="w-full flex flex-col gap-2 border-b border-gray-200 pb-6">
         <h1 className="text-2xl font-black">Inicio</h1>
         <p className="text-textTertiary">
           Configura tu página y sigue los pasos para tener todo listo para tu

--- a/components/dashboard/dashboard-wishlist-list.tsx
+++ b/components/dashboard/dashboard-wishlist-list.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import DeleteWishlistGiftDialog from '@/components/dialog/delete-wishlist-gift-dialog';
+import EditWishlistGiftDialog from '@/components/dialog/edit-wishlist-gift-dialog';
+import GiftTypeBadge from '@/components/dashboard/gift-type-badge';
+import GiftFavoriteBadge from '@/components/dashboard/gift-favorite-badge';
+import { IoGiftOutline, IoSearchOutline, IoSparkles } from 'react-icons/io5';
+import type { Category, Prisma } from '@prisma/client';
+
+type WishlistGiftWithGift = Prisma.WishlistGiftGetPayload<{
+  include: { gift: { include: { image: true } } };
+}>;
+
+type DashboardWishlistListProps = {
+  eventId: string;
+  wishlistId: string;
+  wishlistGifts: WishlistGiftWithGift[];
+  categories: Category[];
+};
+
+const ESTADO_OPTIONS = [
+  { value: 'received', label: 'Regalo recibido' },
+  { value: 'open_contribution', label: 'Contribución abierta' },
+  { value: 'in_list', label: 'En lista' },
+] as const;
+
+function getEstado(wishlistGift: WishlistGiftWithGift) {
+  if (wishlistGift.isFullyPaid) {
+    return {
+      status: 'received' as const,
+      label: 'Regalo recibido',
+      percentage: 100,
+      className: 'bg-success/10 text-success border-transparent',
+    };
+  }
+
+  if (wishlistGift.isGroupGift) {
+    const price = Number(wishlistGift.gift.price) || 0;
+    const contributed = Number(wishlistGift.groupGiftParts) || 0;
+    const percentage =
+      price > 0 ? Math.min(100, Math.round((contributed / price) * 100)) : 0;
+
+    return {
+      status: 'open_contribution' as const,
+      label: 'Contribución abierta',
+      percentage,
+      className: 'bg-warning/10 text-warning border-transparent',
+    };
+  }
+
+  return {
+    status: 'in_list' as const,
+    label: 'En lista',
+    percentage: 0,
+    className: 'bg-gray100 text-textTertiary border-transparent',
+  };
+}
+
+export default function DashboardWishlistList({
+  eventId,
+  wishlistId,
+  wishlistGifts,
+  categories,
+}: DashboardWishlistListProps) {
+  const [search, setSearch] = useState('');
+  const [estadoFilter, setEstadoFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+
+  const categoryNameById = new Map(
+    categories.map(category => [category.id, category.name])
+  );
+  const receivedCount = wishlistGifts.filter(
+    wishlistGift => wishlistGift.isFullyPaid
+  ).length;
+
+  const filteredWishlistGifts = wishlistGifts.filter(wishlistGift => {
+    const matchesSearch = wishlistGift.gift.name
+      .toLowerCase()
+      .includes(search.trim().toLowerCase());
+    const matchesEstado =
+      !estadoFilter || getEstado(wishlistGift).status === estadoFilter;
+    const matchesCategory =
+      !categoryFilter || wishlistGift.gift.categoryId === categoryFilter;
+
+    return matchesSearch && matchesEstado && matchesCategory;
+  });
+
+  return (
+    <div className="flex flex-col gap-6 w-full">
+      <div className="flex flex-col sm:flex-row items-stretch bg-gray50 rounded-lg border border-gray-200 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+        <div className="flex flex-col gap-1 p-6 w-full">
+          <h2 className="text-lg font-bold">Regalos agregados a tu lista</h2>
+          <p className="text-sm text-textTertiary">
+            Según la cantidad de invitados te recomendamos tener 20 regalos
+          </p>
+        </div>
+        <div className="flex gap-3 items-center p-6">
+          <div className="flex justify-center items-center w-10 h-10 bg-white rounded-full border border-gray-200">
+            <IoGiftOutline className="text-xl" />
+          </div>
+          <div className="flex flex-col">
+            <span className="text-lg font-bold">{receivedCount}</span>
+            <span className="text-sm whitespace-nowrap text-textTertiary">
+              Regalos recibidos
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="flex-1 relative">
+          <IoSearchOutline className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <Input
+            type="text"
+            placeholder="Regalo"
+            className="pl-10"
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+          />
+        </div>
+        <select
+          className="px-3 py-2 h-10 text-sm bg-white rounded-md border border-input"
+          value={estadoFilter}
+          onChange={event => setEstadoFilter(event.target.value)}
+        >
+          <option value="">Estado</option>
+          {ESTADO_OPTIONS.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <select
+          className="px-3 py-2 h-10 text-sm bg-white rounded-md border border-input"
+          value={categoryFilter}
+          onChange={event => setCategoryFilter(event.target.value)}
+        >
+          <option value="">Categoria</option>
+          {categories.map(category => (
+            <option key={category.id} value={category.id}>
+              {category.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="bg-white rounded-lg">
+        <div className="hidden sm:grid sm:grid-cols-12 gap-4 px-4 py-3 text-sm font-medium text-gray-600 bg-gray-50 rounded-t-lg">
+          <div className="col-span-4">Nombre y categoría</div>
+          <div className="col-span-2">Tipo</div>
+          <div className="col-span-2">Precio</div>
+          <div className="col-span-2">Estado</div>
+          <div className="col-span-2" />
+        </div>
+
+        {filteredWishlistGifts.length === 0 && (
+          <div className="text-center py-12 text-gray-500">
+            No se encontraron regalos
+          </div>
+        )}
+
+        {filteredWishlistGifts.map(wishlistGift => {
+          const estado = getEstado(wishlistGift);
+
+          return (
+            <div
+              key={wishlistGift.id}
+              className="grid grid-cols-1 sm:grid-cols-12 gap-4 items-center px-4 py-4 border-b border-gray-100 group hover:bg-gray-50"
+            >
+              <div className="flex col-span-4 gap-3 items-center">
+                <div className="flex overflow-hidden justify-center items-center w-12 h-12 bg-gray-200 rounded">
+                  {wishlistGift.gift.image?.url ? (
+                    <Image
+                      src={wishlistGift.gift.image.url}
+                      alt={wishlistGift.gift.name}
+                      className="object-cover w-full h-full"
+                      width={48}
+                      height={48}
+                    />
+                  ) : (
+                    <IoGiftOutline className="text-2xl text-gray-400" />
+                  )}
+                </div>
+                <div>
+                  <p className="font-medium">{wishlistGift.gift.name}</p>
+                  <p className="text-sm text-gray-500">
+                    {categoryNameById.get(wishlistGift.gift.categoryId) ??
+                      'Sin categoría'}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-col col-span-2 gap-2 items-start">
+                <GiftTypeBadge isGroupGift={wishlistGift.isGroupGift} />
+                {wishlistGift.isFavoriteGift && <GiftFavoriteBadge />}
+              </div>
+
+              <div className="col-span-2 text-sm">
+                Gs.{Number(wishlistGift.gift.price).toLocaleString('es-PY')}
+              </div>
+
+              <div className="flex col-span-2 gap-2 items-center text-sm">
+                <Badge className={estado.className}>
+                  <IoSparkles className="mr-1" />
+                  {estado.label}
+                </Badge>
+                {wishlistGift.isGroupGift && !wishlistGift.isFullyPaid && (
+                  <span className="text-gray-500">{estado.percentage}%</span>
+                )}
+              </div>
+
+              <div className="flex col-span-2 gap-2 justify-end opacity-0 transition-opacity group-hover:opacity-100">
+                <EditWishlistGiftDialog
+                  wishlistGiftId={wishlistGift.id}
+                  wishlistId={wishlistId}
+                  eventId={eventId}
+                  gift={wishlistGift.gift}
+                  categories={categories}
+                  isFavoriteGift={wishlistGift.isFavoriteGift}
+                  isGroupGift={wishlistGift.isGroupGift}
+                />
+                <DeleteWishlistGiftDialog
+                  wishlistId={wishlistId}
+                  giftId={wishlistGift.giftId}
+                  giftName={wishlistGift.gift.name}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/dashboard-wishlist-list.tsx
+++ b/components/dashboard/dashboard-wishlist-list.tsx
@@ -194,7 +194,7 @@ export default function DashboardWishlistList({
                 </div>
               </div>
 
-              <div className="flex flex-col col-span-2 gap-2 items-start">
+              <div className="flex flex-col col-span-2 gap-1.5 items-start">
                 <GiftTypeBadge isGroupGift={wishlistGift.isGroupGift} />
                 {wishlistGift.isFavoriteGift && <GiftFavoriteBadge />}
               </div>

--- a/components/dashboard/dashboard-wishlist.tsx
+++ b/components/dashboard/dashboard-wishlist.tsx
@@ -1,10 +1,29 @@
+import { Suspense, lazy } from 'react';
+import Link from 'next/link';
+import { IoAdd, IoGiftOutline } from 'react-icons/io5';
 import { Button } from '@/components/ui/button';
 import EmptyState from '@/components/common/empty-state';
-import { IoAdd } from 'react-icons/io5';
-import { IoGiftOutline } from 'react-icons/io5';
-import Link from 'next/link';
+import DashboardWishlistSkeleton from '@/components/skeletons/dashboard-wishlist';
+import { getEvent } from '@/actions/data/event';
+import { getWishlistGifts } from '@/actions/data/wishlist-gift';
+import { getCategories } from '@/actions/data/category';
 
-export default function DashboardWishlist() {
+const DashboardWishlistList = lazy(
+  () => import('@/components/dashboard/dashboard-wishlist-list')
+);
+
+export default async function DashboardWishlist() {
+  const event = await getEvent();
+
+  if (!event || 'error' in event) {
+    return <div>Error</div>;
+  }
+
+  const [wishlistGifts, categories] = await Promise.all([
+    getWishlistGifts({ searchParams: { wishlistId: event.wishlistId } }),
+    getCategories(),
+  ]);
+
   return (
     <div className="w-full h-full flex items-center flex-col gap-8">
       <div className="w-full flex flex-col sm:flex-row items-center justify-between gap-4 border-b border-gray-200 pb-6">
@@ -17,26 +36,35 @@ export default function DashboardWishlist() {
         </div>
         <Link href="/gifts">
           <Button variant="success" className="gap-2">
-            Agregar regalos
+            Agregar regalo
             <IoAdd className="text-2xl" />
           </Button>
         </Link>
       </div>
 
-      <div>
+      {wishlistGifts.length === 0 ? (
         <EmptyState
           icon={<IoGiftOutline className="text-6xl" />}
           title="Sin regalos en tu lista"
           description="Todavía no tienes ningún regalo agregado, explorá la sección de regalos."
           action={
             <Link href="/gifts">
-              <Button variant="outline" className="gap-2">
+              <Button variant="outline" className="gap-2 hover:bg-gray-100 transition-colors">
                 Agregar regalos
               </Button>
             </Link>
           }
         />
-      </div>
+      ) : (
+        <Suspense fallback={<DashboardWishlistSkeleton />}>
+          <DashboardWishlistList
+            eventId={event.id}
+            wishlistId={event.wishlistId}
+            wishlistGifts={wishlistGifts}
+            categories={categories}
+          />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/components/dashboard/gift-added-badge.tsx
+++ b/components/dashboard/gift-added-badge.tsx
@@ -1,0 +1,24 @@
+import { Badge } from '@/components/ui/badge';
+import { IoBanOutline, IoCheckmark } from 'react-icons/io5';
+
+type GiftAddedBadgeProps = {
+  isInWishlist: boolean;
+};
+
+export default function GiftAddedBadge({ isInWishlist }: GiftAddedBadgeProps) {
+  if (isInWishlist) {
+    return (
+      <Badge className="w-fit gap-1 font-medium bg-success/10 text-success border-transparent">
+        <IoCheckmark />
+        Regalo agregado
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge className="w-fit gap-1 font-medium bg-gray100 text-textPrimary border-transparent">
+      <IoBanOutline />
+      No agregado
+    </Badge>
+  );
+}

--- a/components/dashboard/gift-favorite-badge.tsx
+++ b/components/dashboard/gift-favorite-badge.tsx
@@ -1,0 +1,11 @@
+import { Badge } from '@/components/ui/badge';
+import { IoStarOutline } from 'react-icons/io5';
+
+export default function GiftFavoriteBadge() {
+  return (
+    <Badge className="w-fit gap-1 font-medium bg-gray100 text-textPrimary border-transparent">
+      <IoStarOutline />
+      El que más queremos
+    </Badge>
+  );
+}

--- a/components/dashboard/gift-row.tsx
+++ b/components/dashboard/gift-row.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { IoGiftOutline } from 'react-icons/io5';
+import AddToWishlistButton from '@/components/dashboard/add-to-wishlist-button';
+import GiftTypeBadge from '@/components/dashboard/gift-type-badge';
+import GiftAddedBadge from '@/components/dashboard/gift-added-badge';
+import AddExistingGiftDialog from '@/components/dialog/add-existing-gift-dialog';
+import type { Category, Gift, Image as ImageModel } from '@prisma/client';
+
+type GiftRowProps = {
+  gift: Gift & { image: ImageModel | null };
+  eventId: string;
+  wishlistId: string;
+  categories: Category[];
+  isInWishlist: boolean;
+};
+
+export default function GiftRow({
+  gift,
+  eventId,
+  wishlistId,
+  categories,
+  isInWishlist,
+}: GiftRowProps) {
+  const [open, setOpen] = useState(false);
+  const categoryName =
+    categories.find(category => category.id === gift.categoryId)?.name ??
+    'Sin categoría';
+
+  return (
+    <>
+      <div
+        role={isInWishlist ? undefined : 'button'}
+        tabIndex={isInWishlist ? undefined : 0}
+        onClick={() => {
+          if (!isInWishlist) setOpen(true);
+        }}
+        onKeyDown={event => {
+          if (!isInWishlist && (event.key === 'Enter' || event.key === ' ')) {
+            setOpen(true);
+          }
+        }}
+        className={`grid grid-cols-1 sm:grid-cols-12 gap-4 px-4 py-4 border-b border-gray-100 hover:bg-gray-50 items-center ${
+          isInWishlist ? '' : 'cursor-pointer'
+        }`}
+      >
+        <div className="col-span-4 flex items-center gap-3">
+          <div className="w-12 h-12 bg-gray-200 rounded flex items-center justify-center overflow-hidden shrink-0">
+            {gift.image?.url ? (
+              <Image
+                src={gift.image.url}
+                alt={gift.name}
+                className="w-full h-full object-cover"
+                width={48}
+                height={48}
+              />
+            ) : (
+              <IoGiftOutline className="text-2xl text-gray-400" />
+            )}
+          </div>
+          <div>
+            <p className="font-medium">{gift.name}</p>
+            <p className="text-sm text-gray-500">{categoryName}</p>
+          </div>
+        </div>
+        <div className="col-span-2">
+          <GiftTypeBadge isGroupGift={false} />
+        </div>
+        <div className="col-span-2">
+          <span className="text-sm">
+            Gs.{Number(gift.price).toLocaleString('es-PY')}
+          </span>
+        </div>
+        <div className="col-span-2">
+          <GiftAddedBadge isInWishlist={isInWishlist} />
+        </div>
+        <div className="col-span-2 flex justify-end">
+          {!isInWishlist && <AddToWishlistButton />}
+        </div>
+      </div>
+
+      {!isInWishlist && (
+        <AddExistingGiftDialog
+          open={open}
+          onOpenChange={setOpen}
+          gift={gift}
+          eventId={eventId}
+          wishlistId={wishlistId}
+          categories={categories}
+        />
+      )}
+    </>
+  );
+}

--- a/components/dashboard/gift-type-badge.tsx
+++ b/components/dashboard/gift-type-badge.tsx
@@ -1,0 +1,15 @@
+import { Badge } from '@/components/ui/badge';
+import { IoPeopleOutline, IoPersonOutline } from 'react-icons/io5';
+
+type GiftTypeBadgeProps = {
+  isGroupGift: boolean;
+};
+
+export default function GiftTypeBadge({ isGroupGift }: GiftTypeBadgeProps) {
+  return (
+    <Badge className="w-fit gap-1 font-medium bg-gray100 text-textPrimary border-transparent">
+      {isGroupGift ? <IoPeopleOutline /> : <IoPersonOutline />}
+      {isGroupGift ? 'Regalo Grupal' : 'Regalo Individual'}
+    </Badge>
+  );
+}

--- a/components/dashboard/gifts-filter-bar.tsx
+++ b/components/dashboard/gifts-filter-bar.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import debounce from 'lodash.debounce';
+import { Input } from '@/components/ui/input';
+import { IoSearchOutline } from 'react-icons/io5';
+import type { Category } from '@prisma/client';
+
+type GiftsFilterBarProps = {
+  categories: Category[];
+};
+
+export default function GiftsFilterBar({ categories }: GiftsFilterBarProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
+
+  const [search, setSearch] = useState(searchParams.get('name') ?? '');
+
+  const updateParam = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParamsRef.current.toString());
+
+    if (value) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
+  const debouncedUpdateSearch = useRef(
+    debounce((value: string) => updateParam('name', value), 400)
+  ).current;
+
+  useEffect(() => {
+    return () => {
+      debouncedUpdateSearch.cancel();
+    };
+  }, [debouncedUpdateSearch]);
+
+  return (
+    <div className="flex items-center gap-3 w-full sm:w-auto">
+      <div className="relative flex-1 sm:w-64">
+        <IoSearchOutline className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+        <Input
+          type="text"
+          placeholder="Regalo"
+          className="pl-10"
+          value={search}
+          onChange={event => {
+            setSearch(event.target.value);
+            debouncedUpdateSearch(event.target.value);
+          }}
+        />
+      </div>
+      <select
+        className="h-10 rounded-md border border-input bg-white px-3 py-2 text-sm"
+        defaultValue={searchParams.get('category') ?? ''}
+        onChange={event => updateParam('category', event.target.value)}
+      >
+        <option value="">Categoría</option>
+        {categories.map(category => (
+          <option key={category.id} value={category.id}>
+            {category.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/components/dialog/add-existing-gift-dialog.tsx
+++ b/components/dialog/add-existing-gift-dialog.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { MdOutlineFileUpload } from 'react-icons/md';
+import { CiImageOn } from 'react-icons/ci';
+import { Loader2 } from 'lucide-react';
+import { createGift } from '@/actions/data/gift';
+import { createWishlistGift } from '@/actions/data/wishlist-gift';
+import { uploadGiftImageToAws } from '@/lib/s3';
+import { useToast } from '@/hooks/use-toast';
+import { GiftFormSchema } from '@/schemas/form';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import PriceInput from '@/components/forms/common/price-input';
+import type { Category, Gift, Image as ImageModel } from '@prisma/client';
+
+type AddExistingGiftDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  gift: Gift & { image: ImageModel | null };
+  eventId: string;
+  wishlistId: string;
+  categories: Category[];
+};
+
+export default function AddExistingGiftDialog({
+  open,
+  onOpenChange,
+  gift,
+  eventId,
+  wishlistId,
+  categories,
+}: AddExistingGiftDialogProps) {
+  const [loading, setLoading] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(
+    gift.image?.url ?? null
+  );
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const form = useForm<z.infer<typeof GiftFormSchema>>({
+    resolver: zodResolver(GiftFormSchema),
+    mode: 'all',
+    defaultValues: {
+      name: gift.name,
+      categoryId: gift.categoryId,
+      price: gift.price,
+      isDefault: false,
+      isEditedVersion: false,
+      sourceGiftId: gift.id,
+      eventId,
+      imageUrl: gift.image?.url ?? '',
+      wishlistId,
+      isFavoriteGift: false,
+      isGroupGift: false,
+    },
+  });
+  const { isValid } = form.formState;
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) return;
+
+    setImageFile(file);
+    setImagePreview(URL.createObjectURL(file));
+
+    if (event.target.value) {
+      event.target.value = '';
+    }
+  };
+
+  const resetDialog = () => {
+    form.reset();
+    setImageFile(null);
+    setImagePreview(gift.image?.url ?? null);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    onOpenChange(nextOpen);
+    if (!nextOpen) resetDialog();
+  };
+
+  const onSubmit: SubmitHandler<
+    z.infer<typeof GiftFormSchema>
+  > = async values => {
+    setLoading(true);
+
+    const hasChanges =
+      values.name !== gift.name ||
+      values.categoryId !== gift.categoryId ||
+      values.price !== gift.price ||
+      imageFile !== null;
+
+    let giftId = gift.id;
+
+    if (hasChanges) {
+      let imageUrl = gift.image?.url ?? '';
+
+      if (imageFile) {
+        const uploadResponse = await uploadGiftImageToAws({
+          file: imageFile,
+          eventId,
+        });
+
+        if (uploadResponse.error || !uploadResponse.url) {
+          toast({
+            title: 'Error al subir la imagen',
+            description: uploadResponse.error,
+            variant: 'destructive',
+          });
+          setLoading(false);
+          return;
+        }
+
+        imageUrl = uploadResponse.url;
+      }
+
+      const giftResponse = await createGift({
+        ...values,
+        isDefault: false,
+        isEditedVersion: true,
+        sourceGiftId: gift.id,
+        imageUrl,
+      });
+
+      if (giftResponse.error || !giftResponse.giftId) {
+        toast({
+          title: 'Error al guardar los cambios del regalo',
+          description: giftResponse.error,
+          variant: 'destructive',
+        });
+        setLoading(false);
+        return;
+      }
+
+      giftId = giftResponse.giftId;
+    }
+
+    const linkResponse = await createWishlistGift({
+      wishlistId,
+      eventId,
+      giftId,
+      isFavoriteGift: values.isFavoriteGift,
+      isGroupGift: values.isGroupGift,
+    });
+
+    if (linkResponse.error) {
+      toast({
+        title: 'Error al agregar el regalo a tu lista',
+        description: linkResponse.error,
+        variant: 'destructive',
+      });
+      setLoading(false);
+      return;
+    }
+
+    toast({ title: 'Regalo agregado a tu lista. 🎁' });
+    setLoading(false);
+    handleOpenChange(false);
+    router.refresh();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Agregar regalo</DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="flex flex-col gap-6"
+          >
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium">Imagen del producto</span>
+              <div className="flex items-center gap-4 p-4 border border-dashed rounded-lg border-borderSecondary">
+                <div className="flex overflow-hidden justify-center items-center w-20 h-20 bg-gray-50 rounded-md">
+                  {imagePreview ? (
+                    <Image
+                      src={imagePreview}
+                      alt="Vista previa del regalo"
+                      className="object-cover w-full h-full"
+                      width={80}
+                      height={80}
+                    />
+                  ) : (
+                    <CiImageOn className="text-3xl text-gray-400" />
+                  )}
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <input
+                    id="existingGiftImageUpload"
+                    type="file"
+                    className="hidden"
+                    accept="image/jpeg, image/png, image/heic, image/webp"
+                    ref={fileInputRef}
+                    onChange={handleFileChange}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="gap-2 w-fit"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    Subir imagen
+                    <MdOutlineFileUpload className="text-lg" />
+                  </Button>
+                  <p className="text-xs text-textTertiary">
+                    Se recomienda 1080 x 1080 (1:1), hasta 10 MB
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nombre</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Sofá living" {...field} />
+                  </FormControl>
+                  <FormMessage className="font-normal text-red-600" />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="categoryId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Categoría</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Elegí una categoría" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent className="bg-white">
+                      {categories.map(category => (
+                        <SelectItem key={category.id} value={category.id}>
+                          {category.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage className="font-normal text-red-600" />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="price"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Precio</FormLabel>
+                  <FormControl>
+                    <PriceInput
+                      value={field.value}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                    />
+                  </FormControl>
+                  <FormMessage className="font-normal text-red-600" />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="isFavoriteGift"
+              render={({ field }) => (
+                <FormItem className="flex justify-between items-center">
+                  <div className="flex flex-col gap-1">
+                    <FormLabel>El que más queremos ⭐</FormLabel>
+                    <p className="text-sm text-textTertiary">
+                      Destacá este regalo para tus invitados
+                    </p>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="isGroupGift"
+              render={({ field }) => (
+                <FormItem className="flex justify-between items-center">
+                  <div className="flex flex-col gap-1">
+                    <FormLabel>Regalo grupal</FormLabel>
+                    <p className="text-sm text-textTertiary">
+                      Permite que varios invitados contribuyan a este regalo
+                    </p>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <div className="flex gap-2 justify-end pt-4 -mx-6 -mb-6 px-6 pb-6 bg-gray-50 rounded-b-lg">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                variant="success"
+                className="gap-2"
+                disabled={loading || !isValid}
+              >
+                Agregar a la lista
+                {loading && <Loader2 className="w-4 h-4 animate-spin" />}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/dialog/add-existing-gift-dialog.tsx
+++ b/components/dialog/add-existing-gift-dialog.tsx
@@ -200,7 +200,7 @@ export default function AddExistingGiftDialog({
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(onSubmit)}
-            className="flex flex-col gap-6"
+            className="flex flex-col gap-4"
           >
             <div className="flex flex-col gap-2">
               <span className="text-sm font-medium">Imagen del producto</span>

--- a/components/dialog/create-gift-dialog.tsx
+++ b/components/dialog/create-gift-dialog.tsx
@@ -188,7 +188,7 @@ export default function CreateGiftDialog({
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(onSubmit)}
-            className="flex flex-col gap-6"
+            className="flex flex-col gap-4"
           >
             <div className="flex flex-col gap-2">
               <span className="text-sm font-medium">Imagen del producto</span>

--- a/components/dialog/create-gift-dialog.tsx
+++ b/components/dialog/create-gift-dialog.tsx
@@ -1,0 +1,358 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { IoAdd } from 'react-icons/io5';
+import { MdOutlineFileUpload } from 'react-icons/md';
+import { CiImageOn } from 'react-icons/ci';
+import { Loader2 } from 'lucide-react';
+import { createGift } from '@/actions/data/gift';
+import { createWishlistGift } from '@/actions/data/wishlist-gift';
+import { uploadGiftImageToAws } from '@/lib/s3';
+import { useToast } from '@/hooks/use-toast';
+import { GiftFormSchema } from '@/schemas/form';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import PriceInput from '@/components/forms/common/price-input';
+import type { Category } from '@prisma/client';
+
+type CreateGiftDialogProps = {
+  eventId: string;
+  wishlistId: string;
+  categories: Category[];
+};
+
+export default function CreateGiftDialog({
+  eventId,
+  wishlistId,
+  categories,
+}: CreateGiftDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const form = useForm<z.infer<typeof GiftFormSchema>>({
+    resolver: zodResolver(GiftFormSchema),
+    mode: 'all',
+    defaultValues: {
+      name: '',
+      categoryId: '',
+      price: '',
+      isDefault: false,
+      isEditedVersion: false,
+      sourceGiftId: '',
+      eventId,
+      imageUrl: '',
+      wishlistId,
+      isFavoriteGift: false,
+      isGroupGift: false,
+    },
+  });
+  const { isValid } = form.formState;
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) return;
+
+    setImageFile(file);
+    setImagePreview(URL.createObjectURL(file));
+
+    if (event.target.value) {
+      event.target.value = '';
+    }
+  };
+
+  const resetDialog = () => {
+    form.reset();
+    setImageFile(null);
+    setImagePreview(null);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) resetDialog();
+  };
+
+  const onSubmit: SubmitHandler<
+    z.infer<typeof GiftFormSchema>
+  > = async values => {
+    setLoading(true);
+
+    let imageUrl = '';
+
+    if (imageFile) {
+      const uploadResponse = await uploadGiftImageToAws({
+        file: imageFile,
+        eventId,
+      });
+
+      if (uploadResponse.error || !uploadResponse.url) {
+        toast({
+          title: 'Error al subir la imagen',
+          description: uploadResponse.error,
+          variant: 'destructive',
+        });
+        setLoading(false);
+        return;
+      }
+
+      imageUrl = uploadResponse.url;
+    }
+
+    const giftResponse = await createGift({
+      ...values,
+      isDefault: false,
+      isEditedVersion: false,
+      imageUrl,
+    });
+
+    if (giftResponse.error || !giftResponse.giftId) {
+      toast({
+        title: 'Error al crear el regalo',
+        description: giftResponse.error,
+        variant: 'destructive',
+      });
+      setLoading(false);
+      return;
+    }
+
+    const linkResponse = await createWishlistGift({
+      wishlistId,
+      eventId,
+      giftId: giftResponse.giftId,
+      isFavoriteGift: values.isFavoriteGift,
+      isGroupGift: values.isGroupGift,
+    });
+
+    if (linkResponse.error) {
+      toast({
+        title: 'Error al agregar el regalo a tu lista',
+        description: linkResponse.error,
+        variant: 'destructive',
+      });
+      setLoading(false);
+      return;
+    }
+
+    toast({ title: 'Regalo agregado a tu lista. 🎁' });
+    setLoading(false);
+    handleOpenChange(false);
+    router.refresh();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="success" className="gap-2">
+          Crear regalo
+          <IoAdd className="text-2xl" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Agregar regalo</DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="flex flex-col gap-6"
+          >
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium">Imagen del producto</span>
+              <div className="flex items-center gap-4 p-4 border border-dashed rounded-lg border-borderSecondary">
+                <div className="flex overflow-hidden justify-center items-center w-20 h-20 bg-gray-50 rounded-md">
+                  {imagePreview ? (
+                    <Image
+                      src={imagePreview}
+                      alt="Vista previa del regalo"
+                      className="object-cover w-full h-full"
+                      width={80}
+                      height={80}
+                    />
+                  ) : (
+                    <CiImageOn className="text-3xl text-gray-400" />
+                  )}
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <input
+                    id="giftImageUpload"
+                    type="file"
+                    className="hidden"
+                    accept="image/jpeg, image/png, image/heic, image/webp"
+                    ref={fileInputRef}
+                    onChange={handleFileChange}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="gap-2 w-fit"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    Subir imagen
+                    <MdOutlineFileUpload className="text-lg" />
+                  </Button>
+                  <p className="text-xs text-textTertiary">
+                    Se recomienda 1080 x 1080 (1:1), hasta 10 MB
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nombre</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Sofá living" {...field} />
+                  </FormControl>
+                  <FormMessage className="font-normal text-red-600" />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="categoryId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Categoría</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Elegí una categoría" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent className="bg-white">
+                      {categories.map(category => (
+                        <SelectItem key={category.id} value={category.id}>
+                          {category.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage className="font-normal text-red-600" />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="price"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Precio</FormLabel>
+                  <FormControl>
+                    <PriceInput
+                      value={field.value}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                    />
+                  </FormControl>
+                  <FormMessage className="font-normal text-red-600" />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="isFavoriteGift"
+              render={({ field }) => (
+                <FormItem className="flex justify-between items-center">
+                  <div className="flex flex-col gap-1">
+                    <FormLabel>El que más queremos ⭐</FormLabel>
+                    <p className="text-sm text-textTertiary">
+                      Destacá este regalo para tus invitados
+                    </p>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="isGroupGift"
+              render={({ field }) => (
+                <FormItem className="flex justify-between items-center">
+                  <div className="flex flex-col gap-1">
+                    <FormLabel>Regalo grupal</FormLabel>
+                    <p className="text-sm text-textTertiary">
+                      Permite que varios invitados contribuyan a este regalo
+                    </p>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <div className="flex gap-2 justify-end pt-4 -mx-6 -mb-6 px-6 pb-6 bg-gray-50 rounded-b-lg">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                variant="success"
+                className="gap-2"
+                disabled={loading || !isValid}
+              >
+                Agregar a la lista
+                {loading && <Loader2 className="w-4 h-4 animate-spin" />}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/dialog/delete-wishlist-gift-dialog.tsx
+++ b/components/dialog/delete-wishlist-gift-dialog.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { useWishlistGift } from '@/hooks/dashboard/use-wishlist-gift';
+import { IoTrashOutline } from 'react-icons/io5';
+
+type DeleteWishlistGiftDialogProps = {
+  wishlistId: string;
+  giftId: string;
+  giftName: string;
+};
+
+export default function DeleteWishlistGiftDialog({
+  wishlistId,
+  giftId,
+  giftName,
+}: DeleteWishlistGiftDialogProps) {
+  const { loading, removeFromWishlist } = useWishlistGift();
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button type="button" variant="outline" size="icon">
+          <IoTrashOutline />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            ¿Eliminar &quot;{giftName}&quot; de tu lista?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            Esta acción no se puede deshacer. El regalo dejará de estar
+            visible para tus invitados.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={loading}
+            onClick={() => removeFromWishlist({ wishlistId, giftId })}
+            className="bg-destructive text-white hover:bg-destructive/85 transition-colors"
+          >
+            Si, eliminar
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/dialog/edit-wishlist-gift-dialog.tsx
+++ b/components/dialog/edit-wishlist-gift-dialog.tsx
@@ -1,0 +1,411 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { MdOutlineFileUpload } from 'react-icons/md';
+import { CiImageOn } from 'react-icons/ci';
+import { Loader2 } from 'lucide-react';
+import { IoPencilOutline } from 'react-icons/io5';
+import { createGift, editGift } from '@/actions/data/gift';
+import { editWishlistGift } from '@/actions/data/wishlist-gift';
+import { uploadGiftImageToAws } from '@/lib/s3';
+import { useToast } from '@/hooks/use-toast';
+import { GiftFormSchema } from '@/schemas/form';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import PriceInput from '@/components/forms/common/price-input';
+import type { Category, Gift, Image as ImageModel } from '@prisma/client';
+
+type EditWishlistGiftDialogProps = {
+  wishlistGiftId: string;
+  wishlistId: string;
+  eventId: string;
+  gift: Gift & { image: ImageModel | null };
+  categories: Category[];
+  isFavoriteGift: boolean;
+  isGroupGift: boolean;
+};
+
+export default function EditWishlistGiftDialog({
+  wishlistGiftId,
+  wishlistId,
+  eventId,
+  gift,
+  categories,
+  isFavoriteGift,
+  isGroupGift,
+}: EditWishlistGiftDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(
+    gift.image?.url ?? null
+  );
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const form = useForm<z.infer<typeof GiftFormSchema>>({
+    resolver: zodResolver(GiftFormSchema),
+    mode: 'all',
+    defaultValues: {
+      name: gift.name,
+      categoryId: gift.categoryId,
+      price: gift.price,
+      isDefault: false,
+      isEditedVersion: false,
+      sourceGiftId: gift.id,
+      eventId,
+      imageUrl: gift.image?.url ?? '',
+      wishlistId,
+      isFavoriteGift,
+      isGroupGift,
+    },
+  });
+  const { isValid } = form.formState;
+
+  const resetForm = () => {
+    form.reset({
+      name: gift.name,
+      categoryId: gift.categoryId,
+      price: gift.price,
+      isDefault: false,
+      isEditedVersion: false,
+      sourceGiftId: gift.id,
+      eventId,
+      imageUrl: gift.image?.url ?? '',
+      wishlistId,
+      isFavoriteGift,
+      isGroupGift,
+    });
+    setImageFile(null);
+    setImagePreview(gift.image?.url ?? null);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) resetForm();
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) return;
+
+    setImageFile(file);
+    setImagePreview(URL.createObjectURL(file));
+
+    if (event.target.value) {
+      event.target.value = '';
+    }
+  };
+
+  const onSubmit: SubmitHandler<
+    z.infer<typeof GiftFormSchema>
+  > = async values => {
+    setLoading(true);
+
+    const hasChanges =
+      values.name !== gift.name ||
+      values.categoryId !== gift.categoryId ||
+      values.price !== gift.price ||
+      imageFile !== null;
+
+    let giftId = gift.id;
+
+    if (hasChanges) {
+      let imageUrl = gift.image?.url ?? '';
+
+      if (imageFile) {
+        const uploadResponse = await uploadGiftImageToAws({
+          file: imageFile,
+          eventId,
+        });
+
+        if (uploadResponse.error || !uploadResponse.url) {
+          toast({
+            title: 'Error al subir la imagen',
+            description: uploadResponse.error,
+            variant: 'destructive',
+          });
+          setLoading(false);
+          return;
+        }
+
+        imageUrl = uploadResponse.url;
+      }
+
+      if (gift.isDefault) {
+        // Shared catalog item: fork a personalized copy instead of mutating it.
+        const giftResponse = await createGift({
+          ...values,
+          isDefault: false,
+          isEditedVersion: true,
+          sourceGiftId: gift.id,
+          imageUrl,
+        });
+
+        if (giftResponse.error || !giftResponse.giftId) {
+          toast({
+            title: 'Error al guardar los cambios del regalo',
+            description: giftResponse.error,
+            variant: 'destructive',
+          });
+          setLoading(false);
+          return;
+        }
+
+        giftId = giftResponse.giftId;
+      } else {
+        // Already a personal copy: safe to edit in place.
+        const editResponse = await editGift(
+          { ...values, imageUrl },
+          gift.id
+        );
+
+        if (editResponse.error) {
+          toast({
+            title: 'Error al guardar los cambios del regalo',
+            description: editResponse.error,
+            variant: 'destructive',
+          });
+          setLoading(false);
+          return;
+        }
+      }
+    }
+
+    const response = await editWishlistGift({
+      wishlistGiftId,
+      wishlistId,
+      giftId,
+      isFavoriteGift: values.isFavoriteGift,
+      isGroupGift: values.isGroupGift,
+    });
+
+    if (response.error) {
+      toast({
+        title: 'Error al editar el regalo',
+        description: response.error,
+        variant: 'destructive',
+      });
+      setLoading(false);
+      return;
+    }
+
+    toast({ title: 'Regalo actualizado. ✅' });
+    setLoading(false);
+    handleOpenChange(false);
+    router.refresh();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button type="button" variant="outline" size="icon">
+          <IoPencilOutline />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Editar regalo</DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="flex flex-col gap-6"
+          >
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium">Imagen del producto</span>
+              <div className="flex items-center gap-4 p-4 border border-dashed rounded-lg border-borderSecondary">
+                <div className="flex overflow-hidden justify-center items-center w-20 h-20 bg-gray-50 rounded-md">
+                  {imagePreview ? (
+                    <Image
+                      src={imagePreview}
+                      alt="Vista previa del regalo"
+                      className="object-cover w-full h-full"
+                      width={80}
+                      height={80}
+                    />
+                  ) : (
+                    <CiImageOn className="text-3xl text-gray-400" />
+                  )}
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <input
+                    id="editGiftImageUpload"
+                    type="file"
+                    className="hidden"
+                    accept="image/jpeg, image/png, image/heic, image/webp"
+                    ref={fileInputRef}
+                    onChange={handleFileChange}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="gap-2 w-fit"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    Subir imagen
+                    <MdOutlineFileUpload className="text-lg" />
+                  </Button>
+                  <p className="text-xs text-textTertiary">
+                    Se recomienda 1080 x 1080 (1:1), hasta 10 MB
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nombre</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Sofá living" {...field} />
+                  </FormControl>
+                  <FormMessage className="font-normal text-red-600" />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="categoryId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Categoría</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Elegí una categoría" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent className="bg-white">
+                      {categories.map(category => (
+                        <SelectItem key={category.id} value={category.id}>
+                          {category.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage className="font-normal text-red-600" />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="price"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Precio</FormLabel>
+                  <FormControl>
+                    <PriceInput
+                      value={field.value}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                    />
+                  </FormControl>
+                  <FormMessage className="font-normal text-red-600" />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="isFavoriteGift"
+              render={({ field }) => (
+                <FormItem className="flex justify-between items-center">
+                  <div className="flex flex-col gap-1">
+                    <FormLabel>El que más queremos ⭐</FormLabel>
+                    <p className="text-sm text-textTertiary">
+                      Destacá este regalo para tus invitados
+                    </p>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="isGroupGift"
+              render={({ field }) => (
+                <FormItem className="flex justify-between items-center">
+                  <div className="flex flex-col gap-1">
+                    <FormLabel>Regalo grupal</FormLabel>
+                    <p className="text-sm text-textTertiary">
+                      Permite que varios invitados contribuyan a este regalo
+                    </p>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <div className="flex gap-2 justify-end pt-4 -mx-6 -mb-6 px-6 pb-6 bg-gray-50 rounded-b-lg">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                variant="success"
+                className="gap-2"
+                disabled={loading || !isValid}
+              >
+                Guardar
+                {loading && <Loader2 className="w-4 h-4 animate-spin" />}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/dialog/edit-wishlist-gift-dialog.tsx
+++ b/components/dialog/edit-wishlist-gift-dialog.tsx
@@ -241,7 +241,7 @@ export default function EditWishlistGiftDialog({
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(onSubmit)}
-            className="flex flex-col gap-6"
+            className="flex flex-col gap-4"
           >
             <div className="flex flex-col gap-2">
               <span className="text-sm font-medium">Imagen del producto</span>

--- a/components/forms/common/price-input.tsx
+++ b/components/forms/common/price-input.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { ChangeEvent } from 'react';
+import { Input } from '@/components/ui/input';
+
+type PriceInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+};
+
+export default function PriceInput({
+  value,
+  onChange,
+  onBlur,
+}: PriceInputProps) {
+  const displayValue = value ? Number(value).toLocaleString('es-PY') : '';
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value.replace(/\D/g, ''));
+  };
+
+  return (
+    <Input
+      type="text"
+      inputMode="numeric"
+      placeholder="Gs. 2.000.000"
+      value={displayValue}
+      onChange={handleChange}
+      onBlur={onBlur}
+    />
+  );
+}

--- a/components/forms/dashboard/event-settings.tsx
+++ b/components/forms/dashboard/event-settings.tsx
@@ -24,6 +24,7 @@ import { Calendar as CalendarIcon } from 'lucide-react';
 import { format } from 'date-fns';
 import { Event, User, EventType } from '@prisma/client';
 import { useUpdateEventAndUserData } from '@/hooks/dashboard/use-update-event-and-user-data';
+import { useEventUrl } from '@/hooks/dashboard/use-event-url';
 import { Loader2 } from 'lucide-react';
 import { FaCheck } from 'react-icons/fa6';
 
@@ -44,6 +45,14 @@ export default function DashboardEventSettingsForm({
       currentUser,
       secondaryEventUser,
     });
+
+  const {
+    form: urlForm,
+    onSubmit: onUrlSubmit,
+    isDirty: isUrlDirty,
+    isValid: isUrlValid,
+    loading: urlLoading,
+  } = useEventUrl({ eventId: event.id, url: event.url });
 
   return (
     <Form {...form}>
@@ -91,6 +100,47 @@ export default function DashboardEventSettingsForm({
             </FormItem>
           )}
         />
+
+        <Form {...urlForm}>
+          <FormField
+            control={urlForm.control}
+            name="eventUrl"
+            render={({ field }) => (
+              <FormItem className="max-w-sm">
+                <FormLabel>Dirección de tu evento</FormLabel>
+                <div className="flex items-start gap-2">
+                  <FormControl className="!mt-1.5">
+                    <div className="flex items-center w-full rounded-md border border-input focus-within:ring-1 focus-within:ring-ring">
+                      <span className="pl-3 text-sm text-textTertiary select-none">
+                        wedin.com/e/
+                      </span>
+                      <Input
+                        placeholder="crisley-y-yayo"
+                        className="border-0 !mt-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+                        {...field}
+                      />
+                    </div>
+                  </FormControl>
+                  <Button
+                    type="button"
+                    variant="success"
+                    className="gap-2 mt-1.5 shrink-0"
+                    disabled={urlLoading || !isUrlDirty || !isUrlValid}
+                    onClick={urlForm.handleSubmit(onUrlSubmit)}
+                  >
+                    Guardar
+                    {urlLoading ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <FaCheck className="text-lg" />
+                    )}
+                  </Button>
+                </div>
+                <FormMessage className="font-normal text-red-600" />
+              </FormItem>
+            )}
+          />
+        </Form>
 
         <div className="flex gap-2">
           <FormField

--- a/components/skeletons/dashboard-event-details.tsx
+++ b/components/skeletons/dashboard-event-details.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 export default function DashboardEventDetailsSkeleton() {
   return (
     <section className="w-full h-full flex justify-start items-center flex-col sm:gap-8 gap-12">
-      <div className="w-full flex flex-col gap-4 border-b border-gray-200 pb-6">
+      <div className="w-full flex flex-col gap-2 border-b border-gray-200 pb-6">
         <Skeleton className="h-8 w-[150px] rounded-lg" />
         <Skeleton className="h-6 w-full max-w-xl rounded-lg" />
       </div>

--- a/components/skeletons/dashboard-wishlist.tsx
+++ b/components/skeletons/dashboard-wishlist.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function DashboardWishlistSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 w-full">
+      <Skeleton className="w-full h-20 rounded-lg" />
+      <Skeleton className="w-full h-12 rounded-lg" />
+
+      <div className="flex flex-col gap-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} className="w-full h-16 rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-success focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-success data-[state=unchecked]:bg-gray200",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/hooks/dashboard/use-event-cover.ts
+++ b/hooks/dashboard/use-event-cover.ts
@@ -231,6 +231,12 @@ export function useEventCover({
     z.infer<typeof EventCoverFormSchema>
   > = async data => {
     setLoading(true);
+    // Persisted replacements for images swapped this submit, merged into
+    // existingImages on success so the UI reflects real DB records without
+    // a page reload.
+    const persistedNewImages: ExistingImage[] = [];
+    const persistedReplacedImages: Record<string, ExistingImage> = {};
+
     // Prepare new images to upload
     const newImagesToUpload = newImages.map(({ file, id }) => ({
       file,
@@ -324,11 +330,21 @@ export function useEventCover({
           setLoading(false);
           return;
         }
+
+        if (result.images) {
+          persistedNewImages.push(
+            ...result.images.map(img => ({
+              id: img.id,
+              url: img.url,
+              isNew: false as const,
+            }))
+          );
+        }
       }
     }
 
     if (imagesToReplace.length > 0) {
-      imagesToReplace.map(async image => {
+      for (const image of imagesToReplace) {
         const uploadResponse = await uploadEventCoverImagesToAws({
           files: [image.file],
           eventId,
@@ -358,8 +374,16 @@ export function useEventCover({
             setLoading(false);
             return;
           }
+
+          if (result.image) {
+            persistedReplacedImages[image.replaceId] = {
+              id: result.image.id,
+              url: result.image.url,
+              isNew: false,
+            };
+          }
         }
-      });
+      }
     }
 
     if (imagesToDelete.id.length > 0) {
@@ -410,6 +434,27 @@ export function useEventCover({
     toast({
       title: 'La portada del evento se actualizó con éxito. 📸',
     });
+
+    // Merge server-persisted images into existingImages so the UI reflects
+    // real DB records (ids + permanent URLs) immediately, without waiting
+    // on a route refresh or reloading the page. Replaced images were already
+    // dropped from existingImages by handleRemoveImage, so their persisted
+    // versions are appended alongside the newly-added ones rather than
+    // replaced in place.
+    const mergedImages = [
+      ...existingImages,
+      ...Object.values(persistedReplacedImages),
+      ...persistedNewImages,
+    ];
+    setExistingImages(mergedImages);
+    setInitialImages(mergedImages);
+
+    // Revoke the blob preview URLs for images we just replaced with the
+    // persisted versions above (newly-added ones are freed in this same
+    // pass; handleRemoveImage already revokes any the user discarded).
+    for (const img of [...newImages, ...updatedImages]) {
+      if (img.url) URL.revokeObjectURL(img.url);
+    }
 
     setNewImages([]);
     setUpdatedImages([]);

--- a/hooks/dashboard/use-event-url.ts
+++ b/hooks/dashboard/use-event-url.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { updateEventUrl } from '@/actions/data/event';
+import { useToast } from '@/hooks/use-toast';
+import { EventUrlFormSchema } from '@/schemas/form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+type UseEventUrlProps = {
+  eventId: string;
+  url: string | null;
+};
+
+export function useEventUrl({ eventId, url }: UseEventUrlProps) {
+  const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
+
+  const form = useForm<z.infer<typeof EventUrlFormSchema>>({
+    resolver: zodResolver(EventUrlFormSchema),
+    mode: 'all',
+    defaultValues: {
+      eventId,
+      eventUrl: url ?? '',
+    },
+  });
+  const { isDirty, isValid } = form.formState;
+
+  const onSubmit: SubmitHandler<
+    z.infer<typeof EventUrlFormSchema>
+  > = async values => {
+    setLoading(true);
+
+    const result = await updateEventUrl(values.eventId, values.eventUrl);
+
+    if ('error' in result) {
+      toast({ title: result.error, variant: 'destructive' });
+      setLoading(false);
+      return;
+    }
+
+    toast({ title: 'La dirección de tu evento se actualizó con éxito. 🔗' });
+    form.reset({ eventId, eventUrl: values.eventUrl });
+    setLoading(false);
+  };
+
+  return {
+    form,
+    isDirty,
+    isValid,
+    loading,
+    onSubmit,
+  };
+}

--- a/hooks/dashboard/use-wishlist-gift.ts
+++ b/hooks/dashboard/use-wishlist-gift.ts
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  createWishlistGift,
+  createWishlistGifts,
+  deleteWishlistGift,
+  editWishlistGift,
+} from '@/actions/data/wishlist-gift';
+import { useToast } from '@/hooks/use-toast';
+import type {
+  WishlistGiftCreateSchema,
+  WishlistGiftDeleteSchema,
+  WishlistGiftEditSchema,
+  WishlistGiftsCreateSchema,
+} from '@/schemas/form';
+import type { z } from 'zod';
+
+export function useWishlistGift() {
+  const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const addToWishlist = async (
+    values: z.infer<typeof WishlistGiftCreateSchema>
+  ) => {
+    setLoading(true);
+    const response = await createWishlistGift(values);
+
+    if (response.error) {
+      toast({
+        title: 'Error al agregar el regalo',
+        description: response.error,
+        variant: 'destructive',
+      });
+      setLoading(false);
+      return response;
+    }
+
+    toast({ title: 'Regalo agregado a tu lista. 🎁' });
+    router.refresh();
+    setLoading(false);
+    return response;
+  };
+
+  const removeFromWishlist = async (
+    values: z.infer<typeof WishlistGiftDeleteSchema>
+  ) => {
+    setLoading(true);
+    const response = await deleteWishlistGift(values);
+
+    if (response.error) {
+      toast({
+        title: 'Error al eliminar el regalo',
+        description: response.error,
+        variant: 'destructive',
+      });
+      setLoading(false);
+      return response;
+    }
+
+    toast({ title: 'Regalo eliminado de tu lista.' });
+    router.refresh();
+    setLoading(false);
+    return response;
+  };
+
+  const addAllToWishlist = async (
+    values: z.infer<typeof WishlistGiftsCreateSchema>
+  ) => {
+    setLoading(true);
+    const response = await createWishlistGifts(values);
+
+    if (response.error) {
+      toast({
+        title: 'Error al agregar el paquete',
+        description: response.error,
+        variant: 'destructive',
+      });
+      setLoading(false);
+      return response;
+    }
+
+    toast({ title: 'Paquete agregado a tu lista. 🎁' });
+    router.refresh();
+    setLoading(false);
+    return response;
+  };
+
+  const updateWishlistGift = async (
+    values: z.infer<typeof WishlistGiftEditSchema>
+  ) => {
+    setLoading(true);
+    const response = await editWishlistGift(values);
+
+    if (response.error) {
+      toast({
+        title: 'Error al editar el regalo',
+        description: response.error,
+        variant: 'destructive',
+      });
+      setLoading(false);
+      return response;
+    }
+
+    toast({ title: 'Regalo actualizado. ✅' });
+    router.refresh();
+    setLoading(false);
+    return response;
+  };
+
+  return {
+    loading,
+    addToWishlist,
+    addAllToWishlist,
+    removeFromWishlist,
+    updateWishlistGift,
+  };
+}

--- a/hooks/use-login.tsx
+++ b/hooks/use-login.tsx
@@ -4,12 +4,11 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
 import { login, checkUserExists } from '@/actions/auth/login';
 import { useToast } from '@/hooks/use-toast';
+import { ToastAction } from '@/components/ui/toast';
 import { LoginSchema } from '@/schemas/auth';
 import type { z } from 'zod';
 import { useRouter } from 'next/navigation';
 import debounce from 'lodash.debounce';
-// import { Button } from '@/components/ui/button';
-// import Link from 'next/link';
 
 export function useLoginForm() {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
@@ -37,12 +36,18 @@ export function useLoginForm() {
     if (exists) {
       setUserExists(true);
     } else {
-      //router.push('/register');
       localStorage.setItem('registerEmail', email);
       toast({
         variant: 'destructive',
-        title: 'Error! 😢',
-        description: `No existe cuenta con ${email}`,
+        description: `Todavía no tenés una cuenta con ${email}.`,
+        action: (
+          <ToastAction
+            altText="Registrarme"
+            onClick={() => router.push('/register')}
+          >
+            Registrarme
+          </ToastAction>
+        ),
       });
     }
   };

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -57,6 +57,50 @@ export const uploadEventCoverImagesToAws = async ({
   return { uploadedImages };
 };
 
+export const uploadGiftImageToAws = async ({
+  file,
+  eventId,
+}: {
+  file: File;
+  eventId: string;
+}) => {
+  const checksum = await computeSHA256(file);
+
+  const presignResponse = await getSignedURL({
+    fileName: file.name,
+    fileType: file.type,
+    fileSize: file.size,
+    id: eventId,
+    type: 'eventId',
+    checksum,
+  });
+
+  if (presignResponse.error || !presignResponse?.success) {
+    return { error: presignResponse.error };
+  }
+
+  const imageUrl = presignResponse.success.split('?')[0];
+
+  if (!imageUrl) {
+    return { error: 'Failed to upload image' };
+  }
+
+  const awsImagePosting = await fetch(imageUrl, {
+    method: 'PUT',
+    body: file,
+    headers: {
+      'Content-Type': file.type,
+      metadata: JSON.stringify({ eventId }),
+    },
+  });
+
+  if (!awsImagePosting.ok) {
+    return { error: awsImagePosting.statusText };
+  }
+
+  return { url: imageUrl };
+};
+
 export const deleteEventCoverImageFromAws = async (imageUrl: string) => {
   const deleteResponse = await fetch(imageUrl, {
     method: 'DELETE',

--- a/plan-ultraplan.md
+++ b/plan-ultraplan.md
@@ -277,6 +277,84 @@ and the already-written, unused Zod schemas above.
 - Verify: adding a gift from `/gifts` makes it appear on `/wishlist` with
   correct favorite/group flags; removing it updates both views.
 
+**Status: ✅ Done, plus a substantial post-implementation polish pass** driven
+by manual review/feedback across several follow-up rounds. Everything below
+was verified live (seeded test user + Playwright + direct DB checks), not
+just typechecked.
+
+Delivered as planned: `actions/data/wishlist-gift.ts`, `dashboard-wishlist.tsx`
+rewrite (async Server Component + `Suspense`/`lazy()` list), `/gifts` wiring,
+`hooks/dashboard/use-wishlist-gift.ts`.
+
+Also added, beyond the original scope:
+- `actions/data/category.ts` (`getCategories`) — needed for category
+  `Select`s; not in the original plan text.
+- **Gift image rendering was broken app-wide.** Seed data always had images
+  (`faker.image.url()`); the bug was `getGifts`/`getGiftlists` never
+  `include`-ing the `image` relation, and the UI never rendering it. Fixed
+  in both places — any future list/table of `Gift`s should `include: {
+  image: true }` from the start.
+- **New route `/gifts/lists/[giftlistId]`** — the "Ver paquete" giftlist
+  detail page didn't exist yet; built it (package summary, bulk "Agregar
+  paquete completo", per-gift table). A natural extension of this phase,
+  not originally scoped.
+- **Confirm-before-add modal.** Clicking a catalog gift row (not just its
+  button) now opens a pre-filled, editable "Agregar regalo" dialog
+  (`components/dialog/add-existing-gift-dialog.tsx` +
+  `components/dashboard/gift-row.tsx`) before it's added, instead of adding
+  instantly.
+- **Gift personalization pattern** (relevant to any future gift-editing
+  UI): editing a catalog gift's name/price/category/image forks a
+  personalized copy (`Gift.isEditedVersion: true`, `sourceGiftId`) rather
+  than mutating the shared default catalog item — *unless* the linked gift
+  is already a personal copy, in which case it edits in place (no
+  duplicate proliferation on repeated edits). `GiftCreateSchema`/
+  `createGift` and `editGift` were extended to support this (image upload
+  via nested `image: { create/upsert }`, `sourceGiftId`). Used in both
+  `add-existing-gift-dialog.tsx` and `edit-wishlist-gift-dialog.tsx`.
+- **`/wishlist` and `/gifts` filters wired** (search, Estado, Categoria).
+  `/wishlist` filters client-side against already-fetched data (small
+  dataset, no round-trip needed); `/gifts` filters via URL search params
+  (`components/dashboard/gifts-filter-bar.tsx`), since `getGifts`/
+  `getGiftlists` already supported `name`/`category` params server-side.
+- **Design pass**: shared badge components
+  (`components/dashboard/gift-type-badge.tsx`, `gift-added-badge.tsx`,
+  `gift-favorite-badge.tsx`) replacing plain icon+text. Fixed a bug where
+  the Tipo column always showed "Regalo Grupal" (was reading
+  `Gift.giftlistId`, which just means "belongs to a predefined package" —
+  unrelated to individual/group funding, which is a `WishlistGift`-level
+  concept that doesn't exist until a gift is actually added to someone's
+  list). Removed a redundant duplicate "already added" indicator that
+  appeared twice in the same row.
+- **`app/not-found.tsx`** — no custom 404 existed anywhere in the app;
+  added one (reuses `EmptyState` + the sidebar's wedin logo mark). Also
+  fixed `getGiftlist()`, which used to `throw` on error instead of
+  returning `null` (crashed with an unhandled Prisma error on a malformed
+  ObjectId in the URL) — now matches the rest of the codebase's
+  return-`null`-on-error convention, and the detail page redirects to
+  `/gifts` instead of a raw 404.
+- **Price validation bug fix**: `GiftFormSchema.price` validated string
+  *length* (`max(10)`) while the error message claimed a numeric max of
+  99,999,999 — anything up to ~10 digits silently passed. Now validates
+  the actual numeric value via `.refine()`. Note:
+  `TransactionCreateSchema.amount` and `CreateTransactionParams.amount`
+  (`schemas/form.ts`, `schemas/params.ts`) have the identical bug but are
+  unused until Phase 6 — worth the same fix when that phase wires them up.
+- **`components/forms/common/price-input.tsx`** — new shared masked
+  Guaraní-currency input (strips non-digits live, formats with `es-PY`
+  thousand separators e.g. `2.000.000`). Reused across all three gift
+  dialogs; reuse it for any future PYG amount input (e.g. Phase 6/8).
+
+**Known gap discovered, not fixed (flagged, out of scope for this phase)**:
+`tailwind.config.ts` never mapped the shadcn CSS-variable tokens (`primary`,
+`input`, `ring`, etc.) that `styles/globals.css` defines. Pre-existing,
+affects ~14 shadcn primitives project-wide — most of the app just never hit
+it because it's styled with explicit custom Tailwind colors instead of the
+shadcn defaults. Only patched locally for the new `Switch` component (uses
+`success`/`gray200` instead of `primary`/`input`). Worth a real fix
+(wiring the CSS vars into `tailwind.config.ts`) before adding more shadcn
+components that lean on default theme colors.
+
 ### Phase 3 — Event URL/slug write-path
 Small, blocks Phase 4.
 
@@ -523,3 +601,9 @@ site work).
 - `middleware.ts`, `lib/routes.ts` (no changes needed for the new public route; admin gate is broken, noted above)
 - `components/dashboard/dashboard-home.tsx`, `dashboard-transactions.tsx`, `dashboard-wishlist.tsx`
 - `app/(default)/gifts/page.tsx` (list/row convention to reuse)
+- From Phase 2's polish pass, reusable in later phases (esp. Phase 4's
+  guest-facing gift browsing): `components/dashboard/gift-type-badge.tsx`,
+  `gift-added-badge.tsx`, `gift-favorite-badge.tsx` (pill badge
+  conventions), `components/forms/common/price-input.tsx` (masked Gs.
+  input), `components/dashboard/gifts-filter-bar.tsx` (URL-searchParams
+  filter bar pattern), `app/not-found.tsx` (custom 404, now exists)

--- a/plan-ultraplan.md
+++ b/plan-ultraplan.md
@@ -56,11 +56,28 @@ in this session (not carried over from an earlier draft): `prisma/schema.prisma`
   non-functional, don't rely on it as a real guard without fixing the
   `console.log` into a real redirect first, and call this out explicitly
   rather than silently inheriting broken protection.
-- `lib/routes.ts`'s `publicRoutes` array already contains `/events` (dead,
-  since `isPublicRoute` is unread) — a new `/events/[slug]` route needs
-  **no middleware change**: it's absent from `protectedRoutes` and
-  `onboardingRoute`, so it's already reachable logged-out. Leave
-  `publicRoutes` alone either way.
+- `lib/routes.ts`'s `publicRoutes` array contains `/events` (dead, since
+  `isPublicRoute` is unread, and no `app/events` route folder exists) —
+  this was the earlier draft's assumed guest-route path. **Corrected**:
+  Phase 3's shipped `event-settings.tsx` field already commits the guest
+  URL scheme to `wedin.com/e/{slug}` (label text: `wedin.com/e/`, confirmed
+  live with the user), so Phase 4's new route is `app/e/[slug]`, not
+  `app/events/[slug]`. No middleware change either way: `/e` is absent from
+  `protectedRoutes` and `onboardingRoute`, so it's already reachable
+  logged-out. Leave the dead `/events` entry in `publicRoutes` alone (or
+  delete it as unused cleanup — not load-bearing either way).
+- MongoDB gotcha, confirmed the hard way three times this session (`Image.giftId`,
+  `Event.url`, `User.email`): an optional `@unique` field (`String? @unique`)
+  needs its underlying index converted to `sparse: true` manually. Prisma's
+  schema DSL has no `sparse` option, and `prisma db push` will not create or
+  repair it — a non-sparse unique index only tolerates **one** document
+  missing the field; the second throws `P2002`. Fix via raw Mongo commands
+  (`$runCommandRaw` `dropIndexes` + `createIndexes` with `sparse: true`), and
+  document the manual reindex commands as a comment above the field in
+  `schema.prisma` (see `Image.giftId`, `Event.url`, `User.email` for the
+  pattern to copy). **Apply this immediately** when Phase 1 adds
+  `Transaction.dlocalPaymentId String? @unique` — it will hit the identical
+  bug the moment a second `Transaction` exists without a completed payment.
 - `getEvent()` in `actions/data/event.ts` is session-gated
   (`getCurrentUser()`); `getEventById(eventId)` looks up by ID only, no
   by-`url` lookup exists yet. The guest site needs new, deliberately
@@ -367,6 +384,63 @@ Small, blocks Phase 4.
 - Verify: setting a URL rejects duplicates with a friendly error; valid
   submission persists and is reflected in `getEventById`/new `getEventByUrl`.
 
+**Status: ✅ Done**, live-verified (real login session, real dev DB, no
+mocks), plus follow-up hardening beyond the original scope.
+
+Delivered as planned: `updateEventUrl` action, `hooks/dashboard/use-event-url.ts`,
+a "Dirección de tu evento" field placed top of `event-settings.tsx` (right
+after Fecha del evento, confirmed with the user), prefixed `wedin.com/e/` —
+**this is now the committed guest-route path for Phase 4**, see the
+`/e/[slug]` correction in Verified Facts above.
+
+Also fixed along the way (not originally scoped, discovered while starting
+this phase):
+- **The MongoDB sparse-index gotcha** (see Verified Facts above) — this is
+  what caused the original "Error uploading event images" bug
+  (`Image.giftId`), was proactively found and pre-fixed on `Event.url`
+  before it could bite the new field, then resurfaced twice more: once when
+  `Image.giftId`'s sparse flag reverted outside of `prisma db push` (cause
+  not fully identified — confirmed `db push` itself doesn't revert it), and
+  once on `User.email` (onboarding step 2's partner-user creation, which
+  never sets an email). All three now documented in `schema.prisma` with
+  manual reindex commands.
+- **`updateProfileStepTwo` non-atomic write bug** (`actions/common/onboarding.ts`) —
+  the primary-user update and partner-user create ran as two separate
+  writes; if the second failed (e.g. the `User.email` sparse-index bug
+  above), the first had already committed, silently advancing the user to
+  onboarding step 3 with the partner's name lost. Now wrapped in
+  `prismaClient.$transaction(...)` so both writes succeed or neither does.
+- **`EventUrlFormSchema` hardened to be DNS-label-safe**: lowercase-normalize
+  (`.transform()`), 63-char cap (down from 255), a proper DNS-label regex
+  (alphanumeric start/end, no leading/trailing hyphen) replacing the old
+  charset-only check, and a reserved-word blocklist (`www`, `app`, `api`,
+  `admin`, `dashboard`, `wedin`, etc.). Not needed for the current
+  path-based `/e/{slug}` routing — done so that a **future** move to
+  `{slug}.wedin.app` subdomain routing (discussed, deferred — see below)
+  doesn't require a data-model or validation rewrite, just a routing-layer
+  change. Also fixed a real bug found in the process: `updateEventUrl`
+  validated through the schema but then used the raw, un-normalized input
+  for both the uniqueness check and the DB write, discarding the
+  normalization.
+- **Event-cover form reload anti-pattern removed** (`/event-details`,
+  Presentación section — adjacent bug hunt, not Phase 3 itself): the form
+  used to require a full page refresh after save to reset state; now the
+  mutation response is used to explicitly sync `existingImages`/form state
+  without reloading (see `hooks/dashboard/use-event-cover.ts`). Also fixed
+  an unawaited-`Promise`-in-`.map()` bug in the same hook's image-replace
+  path.
+
+**Deferred, documented for later**: `{eventUrl}.wedin.app` subdomain routing
+(instead of `wedin.com/e/{eventUrl}`) was evaluated and explicitly deferred.
+Real upside (feels like "their own site," matches Notion/Substack-style
+personalization), but real infra cost: wildcard DNS + wildcard TLS is a
+hosting-provider dependency (e.g. Vercel's Wildcard Domains needs a paid
+tier), needs the reserved-word blocklist above to avoid subdomain collisions
+with real platform infrastructure, needs case-insensitive slug handling
+(also done above), and preview/staging deployments don't get the wildcard
+automatically. The schema hardening above keeps this option open cheaply;
+actually building it is its own project, not part of this plan's phases.
+
 ### Phase 4 — Guest-facing public event site
 Net-new route tree outside `(dashboard)`/`(default)`, never importing the
 session-gated `getEvent()`.
@@ -382,7 +456,7 @@ libre, cart):
   function, not a rename of `getEventById` — and `getPublicWishlistGifts(eventId)`.
   Kept as a separate file from `actions/data/event.ts` so no session-gated
   function can accidentally leak into the public route tree.
-- `app/events/[slug]/page.tsx` — resolves via `getEventByUrl`; `notFound()`
+- `app/e/[slug]/page.tsx` — resolves via `getEventByUrl`; `notFound()`
   if missing or "unpublished" (define published = `url` set AND ≥1
   `WishlistGift` row, reused by Phase 9's checklist logic).
 - **Hero section**: render `event.coverMessage` + `event.images` (the same
@@ -413,8 +487,8 @@ libre, cart):
     input surface.
   Both variants end in "Cancelar" / "Agregar al carrito" — added lines are
   cart entries (Phase 5), not immediate transactions.
-- `app/events/layout.tsx` — minimal public layout, no dashboard chrome.
-- Verify: visiting `/events/{url}` in a logged-out/incognito browser renders
+- `app/e/layout.tsx` — minimal public layout, no dashboard chrome.
+- Verify: visiting `/e/{url}` in a logged-out/incognito browser renders
   the event (hero + catalog) without redirecting to `/login`; opening a gift
   card's dialog shows the correct variant (fixed-price vs. monto libre) and
   "Agregar al carrito" adds the right line item.
@@ -483,7 +557,7 @@ exercised.
   secret key already used for request auth (`HMAC-SHA256(ApiKey + rawBody,
   SecretKey)`), so `DLOCAL_GO_WEBHOOK_SECRET` is not a real dLocal Go
   concept and should not be added.
-- New `app/events/[slug]/checkout/page.tsx` +
+- New `app/e/[slug]/checkout/page.tsx` +
   `hooks/checkout/use-checkout.ts` (RHF + `zodResolver(GuestCheckoutSchema)`,
   manual-loading pattern per convention).
 - New webhook route `app/api/webhooks/dlocal/route.ts` — repo's
@@ -582,7 +656,7 @@ Phase 3, in parallel with 4-8.
   (`!!getBankDetails()`), site URL (`!!event.url`, Phase 3). Compute the
   real `X / 6` progress bar (currently hardcoded "1 de 6" / `value={26}`).
   Enable "Ver sitio web" (currently `disabled`) once `event.url` is set,
-  linking to `/events/{url}`.
+  linking to `/e/{url}`.
 - Verify: toggling each underlying condition (adding a gift, setting bank
   details, setting the URL, etc.) updates the corresponding checklist row
   and the progress bar.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,13 @@ enum TransactionStatus {
   REFUNDED
 }
 
+enum PayoutStatus {
+  REQUESTED
+  PROCESSING
+  COMPLETED
+  REJECTED
+}
+
 model Account {
   id                String  @id @default(auto()) @map("_id") @db.ObjectId
   userId            String  @db.ObjectId
@@ -76,6 +83,7 @@ model User {
   TransactionStatusLog TransactionStatusLog[]
   Event                Event?                 @relation(fields: [eventId], references: [id])
   eventId              String?                @db.ObjectId
+  payouts              Payout[]
 }
 
 model Event {
@@ -104,6 +112,7 @@ model Event {
   gifts         Gift[]
   giftAmounts   String[]
   images        Image[]
+  payouts       Payout[]
 
   @@unique([wishlistId])
 }
@@ -122,7 +131,8 @@ model BankDetails {
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
 
-  event Event @relation(fields: [eventId], references: [id])
+  event   Event    @relation(fields: [eventId], references: [id])
+  payouts Payout[]
 }
 
 model Wishlist {
@@ -177,17 +187,20 @@ model WishlistGift {
 }
 
 model Transaction {
-  id             String            @id @default(auto()) @map("_id") @db.ObjectId
-  wishlistGiftId String            @db.ObjectId
-  wishlistId     String?           @db.ObjectId
-  eventId        String            @db.ObjectId
-  amount         String
-  status         TransactionStatus @default(OPEN)
-  notes          String?
-  payerRole      UserType          @default(INVITEE)
-  payeeRole      UserType          @default(ORGANIZER)
-  createdAt      DateTime          @default(now())
-  updatedAt      DateTime          @updatedAt
+  id              String            @id @default(auto()) @map("_id") @db.ObjectId
+  wishlistGiftId  String            @db.ObjectId
+  wishlistId      String?           @db.ObjectId
+  eventId         String            @db.ObjectId
+  amount          String
+  status          TransactionStatus @default(OPEN)
+  notes           String?
+  payerRole       UserType          @default(INVITEE)
+  payeeRole       UserType          @default(ORGANIZER)
+  payerName       String?
+  payerEmail      String?
+  dlocalPaymentId String?           @unique
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
 
   wishlistGift          WishlistGift           @relation(fields: [wishlistGiftId], references: [id])
   event                 Event                  @relation(fields: [eventId], references: [id])
@@ -206,13 +219,32 @@ model TransactionStatusLog {
   previousStatus TransactionStatus
   status         TransactionStatus
   changedAt      DateTime          @default(now())
-  changedById    String            @db.ObjectId
+  changedById    String?           @db.ObjectId
 
-  changedBy   User        @relation(fields: [changedById], references: [id])
+  changedBy   User?       @relation(fields: [changedById], references: [id])
   transaction Transaction @relation(fields: [transactionId], references: [id])
 
   @@index([id, transactionId])
   @@index([changedById])
+}
+
+model Payout {
+  id            String       @id @default(auto()) @map("_id") @db.ObjectId
+  amount        String
+  status        PayoutStatus @default(REQUESTED)
+  eventId       String       @db.ObjectId
+  bankDetailsId String       @db.ObjectId
+  requestedById String       @db.ObjectId
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
+
+  event       Event       @relation(fields: [eventId], references: [id])
+  bankDetails BankDetails @relation(fields: [bankDetailsId], references: [id])
+  requestedBy User        @relation(fields: [requestedById], references: [id])
+
+  @@index([eventId])
+  @@index([bankDetailsId])
+  @@index([requestedById])
 }
 
 model Giftlist {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,15 @@ model User {
   id               String    @id @default(auto()) @map("_id") @db.ObjectId
   name             String?
   lastName         String?
+  // NOTE: the underlying Mongo index (User_email_key) must stay `sparse: true`.
+  // Partner users created during onboarding step 2 (see
+  // updateProfileStepTwo in actions/common/onboarding.ts) never get an
+  // email — same class of bug as Image.giftId and Event.url above: `@unique`
+  // gives no sparse option, so `db push` won't create/repair this — a
+  // non-sparse unique index only allows ONE user with a missing email ever.
+  // If this index is ever recreated (e.g. on a new environment), run manually:
+  //   db.User.dropIndex("User_email_key")
+  //   db.User.createIndex({ email: 1 }, { unique: true, sparse: true, name: "User_email_key" })
   email            String?   @unique
   password         String?
   emailVerified    DateTime?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,6 +91,15 @@ model Event {
   name             String?
   date             DateTime?
   coverMessage     String?
+  // NOTE: the underlying Mongo index (Event_url_key) must stay `sparse: true`.
+  // Events are created without a url (set later, in event-settings — see
+  // Phase 3 of plan-ultraplan.md) and stay that way indefinitely until the
+  // organizer picks one. Same class of bug as Image.giftId above: `@unique`
+  // gives no sparse option, so `db push` won't create/repair this — a
+  // non-sparse unique index only allows ONE event with a missing url ever.
+  // If this index is ever recreated (e.g. on a new environment), run manually:
+  //   db.Event.dropIndex("Event_url_key")
+  //   db.Event.createIndex({ url: 1 }, { unique: true, sparse: true, name: "Event_url_key" })
   url              String?   @unique
   wishlistId       String    @db.ObjectId
   createdAt        DateTime  @default(now())
@@ -287,6 +296,14 @@ model Image {
   updatedAt     DateTime     @updatedAt
   transactionId String?      @db.ObjectId
   eventId       String?      @db.ObjectId
+  // NOTE: the underlying Mongo index (Image_giftId_key) must stay `sparse: true`.
+  // This field is unique but optional, and most Image rows (event cover photos,
+  // giftlist images) never set it. Prisma's `@unique` doesn't expose a sparse
+  // option, so `db push` won't create/repair this — a non-sparse unique index
+  // rejects the 2nd+ document with a missing giftId (P2002 on Image_giftId_key).
+  // If this index is ever recreated (e.g. on a new environment), run manually:
+  //   db.Image.dropIndex("Image_giftId_key")
+  //   db.Image.createIndex({ giftId: 1 }, { unique: true, sparse: true, name: "Image_giftId_key" })
   giftId        String?      @unique @db.ObjectId
   giftlistId    String?      @db.ObjectId
   Transaction   Transaction? @relation(fields: [transactionId], references: [id])

--- a/schemas/form.ts
+++ b/schemas/form.ts
@@ -141,6 +141,45 @@ export const EventDetailsFormSchema = z.object({
   eventGuests: z.string().optional(),
 });
 
+// Reserved so an event slug can never collide with a real subdomain if we
+// move guest sites from /e/{eventUrl} to {eventUrl}.wedin.app later.
+const RESERVED_EVENT_URLS = [
+  'www',
+  'app',
+  'api',
+  'admin',
+  'dashboard',
+  'mail',
+  'ftp',
+  'blog',
+  'help',
+  'support',
+  'status',
+  'cdn',
+  'assets',
+  'static',
+  'img',
+  'images',
+  'docs',
+  'staging',
+  'dev',
+  'test',
+  'ns1',
+  'ns2',
+  'smtp',
+  'webmail',
+  'autodiscover',
+  'cpanel',
+  'shop',
+  'store',
+  'login',
+  'register',
+  'auth',
+  'null',
+  'undefined',
+  'wedin',
+];
+
 export const EventUrlFormSchema = z.object({
   eventId: z.string(),
   eventUrl: z
@@ -149,13 +188,17 @@ export const EventUrlFormSchema = z.object({
     .min(3, {
       message: 'La dirección de tu evento debe contener al menos 3 caracteres',
     })
-    .max(255, {
+    .max(63, {
       message:
-        'La dirección de tu evento debe contener un máximo de 255 caracteres',
+        'La dirección de tu evento debe contener un máximo de 63 caracteres',
     })
-    .refine(value => /^[a-zA-Z0-9-]*$/.test(value), {
+    .transform(value => value.toLowerCase())
+    .refine(value => /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(value), {
       message:
-        'La dirección de tu evento no puede contener caracteres especiales (.*%$#&...)',
+        'La dirección de tu evento solo puede contener letras, números y guiones, y no puede empezar ni terminar con un guión',
+    })
+    .refine(value => !RESERVED_EVENT_URLS.includes(value), {
+      message: 'Esa dirección está reservada, elegí otra.',
     }),
 });
 

--- a/schemas/form.ts
+++ b/schemas/form.ts
@@ -11,7 +11,7 @@ export const GiftFormSchema = z.object({
   price: z
     .string()
     .min(4, { message: 'Precio tiene que ser mayor a 999 guaranies' })
-    .max(10, {
+    .refine(value => Number(value) <= 99999999, {
       message: 'El precio no puede ser mayor de PYG 99,999,999',
     }),
   isDefault: z.boolean().default(false),
@@ -34,6 +34,7 @@ export const GiftEditSchema = GiftPostSchema.pick({
   name: true,
   categoryId: true,
   price: true,
+  imageUrl: true,
 });
 
 export const GiftCreateSchema = GiftPostSchema.pick({
@@ -42,6 +43,7 @@ export const GiftCreateSchema = GiftPostSchema.pick({
   price: true,
   isDefault: true,
   isEditedVersion: true,
+  sourceGiftId: true,
   eventId: true,
   imageUrl: true,
 });


### PR DESCRIPTION
Phase 1: Transaction/TransactionStatusLog schema additions, new Payout model for future wallet withdrawals.

Phase 2: wire "Mi lista" and gift catalog browsing end-to-end.
- actions/data/wishlist-gift.ts + category.ts, /wishlist and /gifts fully wired with search/category/status filters
- Confirm-before-add modal with a gift personalization pattern: editing a catalog gift forks a private copy instead of mutating the shared default, unless it's already a private copy (then edits in place)
- New /gifts/lists/[giftlistId] giftlist detail page
- Fixed gift images not rendering (missing Prisma include), a price validation bug (string-length check vs. the numeric limit it claimed to enforce), and a few crash/404 edge cases (getGiftlist throwing on bad IDs, no custom not-found page anywhere)
- Shared badge components for gift type/added/favorite state