### PR TITLE
Add guest cart with per-event Zustand store (Phase 5)

### DIFF
--- a/app/e/[slug]/page.tsx
+++ b/app/e/[slug]/page.tsx
@@ -24,7 +24,11 @@ export default async function GuestEventPage({ params }: GuestEventPageProps) {
   return (
     <>
       <GuestHero event={event} />
-      <GuestGiftCatalog wishlistGifts={wishlistGifts} categories={categories} />
+      <GuestGiftCatalog
+        eventId={event.id}
+        wishlistGifts={wishlistGifts}
+        categories={categories}
+      />
     </>
   );
 }

--- a/components/cart/cart-drawer.tsx
+++ b/components/cart/cart-drawer.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { IoCartOutline } from 'react-icons/io5';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import CartItemRow from '@/components/cart/cart-item-row';
+import type { CartItem } from '@/hooks/use-cart-store';
+
+type CartDrawerProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: CartItem[];
+  total: number;
+  onRemoveItem: (id: string) => void;
+};
+
+export default function CartDrawer({
+  open,
+  onOpenChange,
+  items,
+  total,
+  onRemoveItem,
+}: CartDrawerProps) {
+  const pathname = usePathname();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-lg"
+        onOpenAutoFocus={event => event.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Mi carrito</DialogTitle>
+        </DialogHeader>
+
+        {items.length === 0 ? (
+          <div className="flex flex-col gap-2 items-center py-12 text-center text-gray-500">
+            <IoCartOutline className="text-3xl text-gray-300" />
+            Todavía no agregaste ningún regalo
+          </div>
+        ) : (
+          <div className="flex overflow-y-auto flex-col divide-y divide-gray-100 max-h-96">
+            {items.map(item => (
+              <CartItemRow key={item.id} item={item} onRemove={onRemoveItem} />
+            ))}
+          </div>
+        )}
+
+        {items.length > 0 && (
+          <div className="flex flex-col gap-3 pt-4 -mx-6 -mb-6 px-6 pb-6 bg-gray-50 rounded-b-lg">
+            <div className="flex justify-between items-center">
+              <span className="text-textTertiary">Total en efectivo</span>
+              <span className="text-lg font-semibold">
+                Gs. {total.toLocaleString('es-PY')}
+              </span>
+            </div>
+            <Button variant="success" className="w-full" asChild>
+              <Link href={`${pathname}/checkout`}>Ir a pagar</Link>
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/cart/cart-item-row.tsx
+++ b/components/cart/cart-item-row.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Image from 'next/image';
+import { IoGiftOutline, IoTrashOutline } from 'react-icons/io5';
+import { Button } from '@/components/ui/button';
+import type { CartItem } from '@/hooks/use-cart-store';
+
+type CartItemRowProps = {
+  item: CartItem;
+  onRemove: (id: string) => void;
+};
+
+export default function CartItemRow({ item, onRemove }: CartItemRowProps) {
+  return (
+    <div className="flex gap-3 items-center py-3">
+      <div className="flex overflow-hidden justify-center items-center w-16 h-16 bg-gray-100 rounded-md shrink-0">
+        {item.giftImageUrl ? (
+          <Image
+            src={item.giftImageUrl}
+            alt={item.giftName}
+            className="object-cover w-full h-full"
+            width={64}
+            height={64}
+          />
+        ) : (
+          <IoGiftOutline className="text-2xl text-gray-400" />
+        )}
+      </div>
+      <div className="flex flex-col flex-1 gap-1 min-w-0">
+        <p className="truncate font-normal text-base">{item.giftName}</p>
+        <p className="font-medium text-lg">
+          Gs. {Number(item.amount).toLocaleString('es-PY')}
+        </p>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Quitar del carrito"
+        onClick={() => onRemove(item.id)}
+      >
+        <IoTrashOutline className="text-lg text-gray-500" />
+      </Button>
+    </div>
+  );
+}

--- a/components/cart/cart-sticky-bar.tsx
+++ b/components/cart/cart-sticky-bar.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { IoCartOutline } from 'react-icons/io5';
+import { Button } from '@/components/ui/button';
+
+type CartStickyBarProps = {
+  itemCount: number;
+  total: number;
+  onOpenCart: () => void;
+};
+
+export default function CartStickyBar({
+  itemCount,
+  total,
+  onOpenCart,
+}: CartStickyBarProps) {
+  if (itemCount === 0) return null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 text-white bg-textPrimary">
+      <div className="flex justify-between items-center px-4 py-3 mx-auto max-w-7xl sm:px-6 lg:px-8">
+        <div className="flex gap-6 sm:gap-10">
+          <div className="flex flex-col">
+            <span className="text-xs text-gray-300">Cantidad de regalos</span>
+            <span className="text-lg font-semibold">{itemCount}</span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-xs text-gray-300">En efectivo</span>
+            <span className="text-lg font-semibold">
+              Gs. {total.toLocaleString('es-PY')}
+            </span>
+          </div>
+        </div>
+        <Button variant="outline" className="gap-2 text-black" onClick={onOpenCart}>
+          Ver mi carrito
+          <IoCartOutline className="text-lg" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/guest/guest-gift-catalog.tsx
+++ b/components/guest/guest-gift-catalog.tsx
@@ -4,23 +4,22 @@ import { useState } from 'react';
 import { IoGiftOutline, IoPeopleOutline, IoPersonOutline, IoSearchOutline } from 'react-icons/io5';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
+import { useStore } from '@/hooks/use-store';
+import { useCartStore } from '@/hooks/use-cart-store';
 import GuestGiftCard, {
   type WishlistGiftWithGift,
 } from '@/components/guest/guest-gift-card';
 import GiftContributionDialog from '@/components/dialog/gift-contribution-dialog';
+import CartStickyBar from '@/components/cart/cart-sticky-bar';
+import CartDrawer from '@/components/cart/cart-drawer';
 import { getGiftProgress } from '@/components/guest/gift-progress';
 import type { Category } from '@prisma/client';
 
 type TypeFilter = 'todos' | 'individual' | 'grupal';
 type SortOption = 'recientes' | 'precio-asc' | 'precio-desc';
 
-type CartItem = {
-  wishlistGiftId: string;
-  giftName: string;
-  amount: string;
-};
-
 type GuestGiftCatalogProps = {
+  eventId: string;
   wishlistGifts: WishlistGiftWithGift[];
   categories: Category[];
 };
@@ -32,27 +31,34 @@ const TYPE_FILTERS: { value: TypeFilter; label: string; icon: React.ReactNode }[
 ];
 
 export default function GuestGiftCatalog({
+  eventId,
   wishlistGifts,
   categories,
 }: GuestGiftCatalogProps) {
   const { toast } = useToast();
+  const cartStore = useCartStore(eventId);
+  const cartItems = useStore(cartStore, state => state.items) ?? [];
+
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('todos');
   const [search, setSearch] = useState('');
   const [categoryFilter, setCategoryFilter] = useState('');
   const [sort, setSort] = useState<SortOption>('recientes');
-  const [cartItems, setCartItems] = useState<CartItem[]>([]);
+  const [isCartOpen, setIsCartOpen] = useState(false);
   const [selectedWishlistGift, setSelectedWishlistGift] =
     useState<WishlistGiftWithGift | null>(null);
 
+  const cartTotal = cartItems.reduce(
+    (sum, item) => sum + (Number(item.amount) || 0),
+    0
+  );
+
   const addToCart = (wishlistGift: WishlistGiftWithGift, amount: string) => {
-    setCartItems(previous => [
-      ...previous,
-      {
-        wishlistGiftId: wishlistGift.id,
-        giftName: wishlistGift.gift.name,
-        amount,
-      },
-    ]);
+    cartStore.getState().addItem({
+      wishlistGiftId: wishlistGift.id,
+      giftName: wishlistGift.gift.name,
+      giftImageUrl: wishlistGift.gift.image?.url ?? null,
+      amount,
+    });
     toast({
       title: 'Agregado al carrito 🎁',
       description: `${wishlistGift.gift.name} — Gs. ${Number(amount).toLocaleString(
@@ -104,7 +110,9 @@ export default function GuestGiftCatalog({
   return (
     <section
       id="lista-de-regalos"
-      className="px-4 py-8 sm:py-12 mx-auto max-w-7xl sm:px-6 lg:px-8"
+      className={`px-4 py-8 sm:py-12 mx-auto max-w-7xl sm:px-6 lg:px-8 ${
+        cartItems.length > 0 ? 'pb-24' : ''
+      }`}
     >
       <h2 className="mb-6 text-3xl font-medium">Lista de regalos</h2>
 
@@ -192,6 +200,22 @@ export default function GuestGiftCatalog({
           onAddToCart={handleContributionSubmit}
         />
       )}
+
+      <CartStickyBar
+        itemCount={cartItems.length}
+        total={cartTotal}
+        onOpenCart={() => setIsCartOpen(true)}
+      />
+      <CartDrawer
+        open={isCartOpen}
+        onOpenChange={setIsCartOpen}
+        items={cartItems}
+        total={cartTotal}
+        onRemoveItem={id => {
+          cartStore.getState().removeItem(id);
+          if (cartItems.length === 1) setIsCartOpen(false);
+        }}
+      />
     </section>
   );
 }

--- a/hooks/use-cart-store.ts
+++ b/hooks/use-cart-store.ts
@@ -1,0 +1,57 @@
+import { create, type StoreApi, type UseBoundStore } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+export type CartItem = {
+  id: string;
+  wishlistGiftId: string;
+  giftName: string;
+  giftImageUrl: string | null;
+  amount: string;
+};
+
+type CartState = {
+  items: CartItem[];
+  addItem: (item: Omit<CartItem, 'id'>) => void;
+  removeItem: (id: string) => void;
+  clear: () => void;
+};
+
+type CartStore = UseBoundStore<StoreApi<CartState>>;
+
+// A guest could have multiple couples' sites open in the same browser, so
+// the store — and its localStorage key — must be scoped per event, not
+// global like `use-sidebar.ts`. One store instance is created per eventId
+// and cached for the lifetime of the tab.
+const storesByEventId = new Map<string, CartStore>();
+
+function createCartStore(eventId: string): CartStore {
+  return create<CartState>()(
+    persist(
+      set => ({
+        items: [],
+        addItem: item =>
+          set(state => ({
+            items: [...state.items, { ...item, id: crypto.randomUUID() }],
+          })),
+        removeItem: id =>
+          set(state => ({
+            items: state.items.filter(item => item.id !== id),
+          })),
+        clear: () => set({ items: [] }),
+      }),
+      {
+        name: `wedin-cart-${eventId}`,
+        storage: createJSONStorage(() => localStorage),
+      }
+    )
+  );
+}
+
+export function useCartStore(eventId: string): CartStore {
+  let store = storesByEventId.get(eventId);
+  if (!store) {
+    store = createCartStore(eventId);
+    storesByEventId.set(eventId, store);
+  }
+  return store;
+}

--- a/plan-ultraplan.md
+++ b/plan-ultraplan.md
@@ -650,6 +650,60 @@ today; this phase sets the pattern.
 - Verify: adding/removing cart items persists across a page refresh
   (localStorage), scoped per event.
 
+**Status: ✅ Done**, live-verified (Playwright against the real dev DB and
+dev server, not just typechecked): add-to-cart, sticky-bar visibility,
+drawer open, localStorage persistence across a full page reload, and
+remove-to-empty all confirmed with zero console errors.
+
+Delivered as planned: `hooks/use-cart-store.ts`, `components/cart/`
+(`cart-sticky-bar.tsx`, `cart-drawer.tsx`, `cart-item-row.tsx`), wired into
+`guest-gift-catalog.tsx` in place of the Phase 4 placeholder `useState`
+array. No "header badge" component was built — the confirmed Figma
+reference (`phase5-sticky-cart-bar-v1.png`) only shows "Compartir lista" in
+the header; cart affordance is entirely the sticky bar + drawer.
+
+**Correction to this phase's premise**: "zero stores exist today" was
+wrong — `hooks/use-sidebar.ts` is already a working `create(persist(...))`
+Zustand store (dashboard sidebar open/hover state), consumed via
+`useStore(useSidebar, x => x)` in `admin-panel-layout.tsx`/`sidebar.tsx`.
+What's actually new in this phase is a **per-key store factory**: the
+sidebar store is a single global singleton, but the cart needs one
+`localStorage` key per event (`wedin-cart-{eventId}`), so
+`hooks/use-cart-store.ts` exports `useCartStore(eventId)`, which
+lazily creates and caches one store instance per `eventId` in a
+module-level `Map` (not a React hook itself — no hooks called inside it,
+safe to call unconditionally from render).
+
+**Real bug found and fixed, relevant to any future `useStore` consumer**:
+routing store *actions* (`addItem`/`removeItem`) through
+`useStore(cartStore, selector)` — as the plan originally specified for
+"every client consumer" — triggered a live React warning, "Cannot update a
+component while rendering a different component," on first paint (confirmed
+via Playwright console capture; reproduced with the plan's literal wording,
+disappeared once fixed). Root cause: `useStore`'s hydration-safe wrapper
+(`useState` + `useEffect` re-emit) exists to avoid an SSR/CSR mismatch for
+*persisted state values* (e.g. `items`, whose initial value differs between
+server and a hydrated-from-localStorage client) — it's not needed for
+*actions*, which are referentially stable functions untouched by
+hydration. Calling it three times per render (once per selector) on the
+same store was the trigger. Fixed by only wrapping the reactive `items`
+selector in `useStore`; actions are invoked directly via
+`cartStore.getState().addItem(...)` / `.removeItem(...)`, no hook needed.
+**Rule of thumb for Phase 6+**: `useStore(store, selector)` for state you
+render; `store.getState().action(...)` for calls inside event handlers.
+
+**Post-implementation UX fix**, caught by the user reviewing the live
+dialog: removing a cart item left an empty "Todavía no agregaste ningún
+regalo" dialog open instead of closing it — confusing once the cart is
+empty, since the sticky bar (the only other cart entry point) has already
+disappeared by then. Fixed in `guest-gift-catalog.tsx`'s `onRemoveItem`:
+checks `cartItems.length === 1` (the pre-removal count) before calling
+`removeItem`, and closes the dialog (`setIsCartOpen(false)`) when that
+removal empties the cart. Live-verified via Playwright: dialog is gone
+after removing the last item, zero console errors.
+
+**Open PR**: `feature/guest-cart` → base `docs/guest-checkout-wallet-plan`.
+
 ### Phase 6 — Checkout + dLocal Go integration
 Largest phase. dLocal Go's API shape is now verified (see "dLocal Go API
 research" above) — `POST /v1/payments` with `currency: "PYG"`, `country:


### PR DESCRIPTION
Replaces Phase 4's placeholder local-state cart in guest-gift-catalog.tsx with a real persisted cart: hooks/use-cart-store.ts (one Zustand store per event, localStorage-scoped), components/cart/ (sticky bar, drawer, item row). Drawer auto-closes when the last item is removed.