### PR TITLE
Improve guest cart UX and add mobile 2-column gift grid

### DIFF
--- a/components/cart/cart-drawer.tsx
+++ b/components/cart/cart-drawer.tsx
@@ -19,6 +19,7 @@ type CartDrawerProps = {
   items: CartItem[];
   total: number;
   onRemoveItem: (id: string) => void;
+  onEditItem: (item: CartItem) => void;
 };
 
 export default function CartDrawer({
@@ -27,13 +28,14 @@ export default function CartDrawer({
   items,
   total,
   onRemoveItem,
+  onEditItem,
 }: CartDrawerProps) {
   const pathname = usePathname();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-w-lg"
+        className="flex flex-col min-h-[42vh] sm:min-h-[36vh] max-w-lg max-h-[56vh]"
         onOpenAutoFocus={event => event.preventDefault()}
       >
         <DialogHeader>
@@ -41,29 +43,46 @@ export default function CartDrawer({
         </DialogHeader>
 
         {items.length === 0 ? (
-          <div className="flex flex-col gap-2 items-center py-12 text-center text-gray-500">
+          <div className="flex flex-col flex-1 gap-2 justify-center items-center text-center text-gray-500">
             <IoCartOutline className="text-3xl text-gray-300" />
             Todavía no agregaste ningún regalo
           </div>
         ) : (
-          <div className="flex overflow-y-auto flex-col divide-y divide-gray-100 max-h-96">
-            {items.map(item => (
-              <CartItemRow key={item.id} item={item} onRemove={onRemoveItem} />
-            ))}
-          </div>
-        )}
-
-        {items.length > 0 && (
-          <div className="flex flex-col gap-3 pt-4 -mx-6 -mb-6 px-6 pb-6 bg-gray-50 rounded-b-lg">
+          <>
+            <div className="overflow-y-auto flex-1 divide-y divide-gray-100">
+              {items.map(item => (
+                <CartItemRow
+                  key={item.id}
+                  item={item}
+                  onRemove={onRemoveItem}
+                  onEdit={onEditItem}
+                />
+              ))}
+            </div>
             <div className="flex justify-between items-center">
-              <span className="text-textTertiary">Total en efectivo</span>
+              <span className="text-textTertiary">Subtotal</span>
               <span className="text-lg font-semibold">
                 Gs. {total.toLocaleString('es-PY')}
               </span>
             </div>
-            <Button variant="success" className="w-full" asChild>
-              <Link href={`${pathname}/checkout`}>Ir a pagar</Link>
-            </Button>
+          </>
+        )}
+
+        {items.length > 0 && (
+          <div className="pt-4 -mx-6 -mb-6 px-6 pb-6 bg-gray-50 rounded-b-lg">
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                className="flex-[3] bg-gray-100 hover:bg-gray-200 transition-colors border-none"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancelar
+              </Button>
+              <Button variant="success" className="flex-[7]" asChild>
+                <Link href={`${pathname}/checkout`}>Ir a pagar</Link>
+              </Button>
+            </div>
           </div>
         )}
       </DialogContent>

--- a/components/cart/cart-item-row.tsx
+++ b/components/cart/cart-item-row.tsx
@@ -1,16 +1,21 @@
 'use client';
 
 import Image from 'next/image';
-import { IoGiftOutline, IoTrashOutline } from 'react-icons/io5';
+import { IoGiftOutline, IoPencilOutline, IoTrashOutline } from 'react-icons/io5';
 import { Button } from '@/components/ui/button';
 import type { CartItem } from '@/hooks/use-cart-store';
 
 type CartItemRowProps = {
   item: CartItem;
   onRemove: (id: string) => void;
+  onEdit: (item: CartItem) => void;
 };
 
-export default function CartItemRow({ item, onRemove }: CartItemRowProps) {
+export default function CartItemRow({
+  item,
+  onRemove,
+  onEdit,
+}: CartItemRowProps) {
   return (
     <div className="flex gap-3 items-center py-3">
       <div className="flex overflow-hidden justify-center items-center w-16 h-16 bg-gray-100 rounded-md shrink-0">
@@ -32,15 +37,30 @@ export default function CartItemRow({ item, onRemove }: CartItemRowProps) {
           Gs. {Number(item.amount).toLocaleString('es-PY')}
         </p>
       </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        aria-label="Quitar del carrito"
-        onClick={() => onRemove(item.id)}
-      >
-        <IoTrashOutline className="text-lg text-gray-500" />
-      </Button>
+      <div className="flex gap-1 items-center shrink-0">
+        {item.isGroupGift && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Editar contribución"
+            onClick={() => onEdit(item)}
+            className="hover:bg-gray-100 transition-colors"
+          >
+            <IoPencilOutline className="text-lg text-gray-500" />
+          </Button>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Quitar del carrito"
+          onClick={() => onRemove(item.id)}
+          className="hover:bg-gray-100 transition-colors"
+        >
+          <IoTrashOutline className="text-lg text-gray-500" />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/components/cart/cart-sticky-bar.tsx
+++ b/components/cart/cart-sticky-bar.tsx
@@ -18,14 +18,41 @@ export default function CartStickyBar({
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-40 text-white bg-textPrimary">
-      <div className="flex justify-between items-center px-4 py-3 mx-auto max-w-7xl sm:px-6 lg:px-8">
+      {/* Compact single-line bar below sm */}
+      <div className="flex justify-between items-center px-4 py-3 mx-auto max-w-7xl sm:hidden">
+        <div className="flex gap-6 items-center">
+          <div className="relative">
+            <IoCartOutline className="text-3xl" />
+            <span className="flex absolute -top-1.5 -right-1.5 justify-center items-center w-4 h-4 text-[10px] font-semibold text-textPrimary bg-white rounded-full">
+              {itemCount}
+            </span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-gray-300 text-xs">Subtotal</span>
+            <span className="text-lg font-semibold">
+              Gs. {total.toLocaleString('es-PY')}
+            </span>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-black"
+          onClick={onOpenCart}
+        >
+          Ver mi carrito
+        </Button>
+      </div>
+
+      {/* Original two-stat bar from sm and up */}
+      <div className="hidden justify-between items-center p-4 mx-auto max-w-7xl sm:flex sm:px-6 lg:px-8">
         <div className="flex gap-6 sm:gap-10">
           <div className="flex flex-col">
             <span className="text-xs text-gray-300">Cantidad de regalos</span>
             <span className="text-lg font-semibold">{itemCount}</span>
           </div>
           <div className="flex flex-col">
-            <span className="text-xs text-gray-300">En efectivo</span>
+            <span className="text-xs text-gray-300">Subtotal</span>
             <span className="text-lg font-semibold">
               Gs. {total.toLocaleString('es-PY')}
             </span>

--- a/components/dashboard/gift-favorite-badge.tsx
+++ b/components/dashboard/gift-favorite-badge.tsx
@@ -1,11 +1,24 @@
 import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 import { IoStarOutline } from 'react-icons/io5';
 
-export default function GiftFavoriteBadge() {
+type GiftFavoriteBadgeProps = {
+  className?: string;
+};
+
+export default function GiftFavoriteBadge({
+  className,
+}: GiftFavoriteBadgeProps) {
   return (
-    <Badge className="w-fit gap-1 font-medium bg-gray100 text-textPrimary border-transparent">
+    <Badge
+      className={cn(
+        'w-fit gap-1 font-medium bg-gray100 text-textPrimary border-transparent',
+        className
+      )}
+    >
       <IoStarOutline />
-      El que más queremos
+      <span className="sm:hidden">Favorito</span>
+      <span className="hidden sm:inline">El que más queremos</span>
     </Badge>
   );
 }

--- a/components/dashboard/gift-type-badge.tsx
+++ b/components/dashboard/gift-type-badge.tsx
@@ -1,13 +1,23 @@
 import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 import { IoPeopleOutline, IoPersonOutline } from 'react-icons/io5';
 
 type GiftTypeBadgeProps = {
   isGroupGift: boolean;
+  className?: string;
 };
 
-export default function GiftTypeBadge({ isGroupGift }: GiftTypeBadgeProps) {
+export default function GiftTypeBadge({
+  isGroupGift,
+  className,
+}: GiftTypeBadgeProps) {
   return (
-    <Badge className="w-fit gap-1 font-medium bg-gray100 text-textPrimary border-transparent">
+    <Badge
+      className={cn(
+        'w-fit gap-1 font-medium bg-gray100 text-textPrimary border-transparent',
+        className
+      )}
+    >
       {isGroupGift ? <IoPeopleOutline /> : <IoPersonOutline />}
       {isGroupGift ? 'Regalo Grupal' : 'Regalo Individual'}
     </Badge>

--- a/components/dialog/gift-contribution-dialog.tsx
+++ b/components/dialog/gift-contribution-dialog.tsx
@@ -55,6 +55,7 @@ type GiftContributionDialogProps = {
   remaining: number;
   percentage: number;
   onAddToCart: (amount: string) => void;
+  initialAmount?: string;
 };
 
 export default function GiftContributionDialog({
@@ -65,21 +66,27 @@ export default function GiftContributionDialog({
   remaining,
   percentage,
   onAddToCart,
+  initialAmount,
 }: GiftContributionDialogProps) {
   const contributionSchema = createContributionSchema(remaining);
 
   const form = useForm<z.infer<typeof contributionSchema>>({
     resolver: zodResolver(contributionSchema),
     mode: 'all',
-    defaultValues: { amount: '', completeRemaining: false },
+    defaultValues: { amount: initialAmount ?? '', completeRemaining: false },
   });
   const { isValid } = form.formState;
   const completeRemaining = form.watch('completeRemaining');
   const amountValue = form.watch('amount');
 
   const suggestedAmounts = [0.1, 0.25, 0.5]
-    .map(fraction => Math.max(1000, Math.round((remaining * fraction) / 1000) * 1000))
-    .filter((amount, index, all) => amount < remaining && all.indexOf(amount) === index);
+    .map(fraction =>
+      Math.max(1000, Math.round((remaining * fraction) / 1000) * 1000)
+    )
+    .filter(
+      (amount, index, all) =>
+        amount < remaining && all.indexOf(amount) === index
+    );
 
   const handleSelectSuggestedAmount = (amount: number) => {
     form.setValue('completeRemaining', false);
@@ -87,8 +94,12 @@ export default function GiftContributionDialog({
   };
 
   useEffect(() => {
-    if (!open) form.reset({ amount: '', completeRemaining: false });
-  }, [open, form]);
+    if (open) {
+      form.reset({ amount: initialAmount ?? '', completeRemaining: false });
+    } else {
+      form.reset({ amount: '', completeRemaining: false });
+    }
+  }, [open, initialAmount, form]);
 
   useEffect(() => {
     if (completeRemaining) {
@@ -215,10 +226,16 @@ export default function GiftContributionDialog({
                 type="button"
                 variant="outline"
                 onClick={() => onOpenChange(false)}
+                className="flex-[3] bg-gray-100 hover:bg-gray-200 transition-colors border-none"
               >
                 Cancelar
               </Button>
-              <Button type="submit" variant="success" disabled={!isValid}>
+              <Button
+                type="submit"
+                variant="success"
+                disabled={!isValid}
+                className="flex-[7]"
+              >
                 Agregar al carrito
               </Button>
             </div>

--- a/components/guest/guest-gift-card.tsx
+++ b/components/guest/guest-gift-card.tsx
@@ -67,18 +67,25 @@ export default function GuestGiftCard({
             </div>
           </div>
         )}
-        <div className="flex absolute bottom-3 left-3 flex-col gap-1.5 items-start">
-          <GiftTypeBadge isGroupGift={wishlistGift.isGroupGift} />
-          {wishlistGift.isFavoriteGift && <GiftFavoriteBadge />}
+        <div className="flex absolute bottom-3 left-3 flex-col gap-1.5 items-start max-w-[calc(100%-1.5rem)]">
+          <GiftTypeBadge
+            isGroupGift={wishlistGift.isGroupGift}
+            className="text-[11px] px-2 sm:text-xs sm:px-2.5"
+          />
+          {wishlistGift.isFavoriteGift && (
+            <GiftFavoriteBadge className="text-[11px] px-2 sm:text-xs sm:px-2.5" />
+          )}
         </div>
       </div>
 
       <div className="flex flex-col gap-1">
-        <p className="font-normal text-lg truncate">{gift.name}</p>
+        <p className="font-normal text-sm line-clamp-2 min-h-[2.5rem] sm:min-h-0 sm:text-lg sm:truncate sm:line-clamp-none">
+          {gift.name}
+        </p>
 
-        {wishlistGift.isGroupGift ? ( 
+        {wishlistGift.isGroupGift ? (
           <div className="flex flex-col gap-1.5">
-            <div className="flex justify-between text-sm">
+            <div className="flex flex-col gap-0.5 text-xs sm:flex-row sm:justify-between sm:gap-0 sm:text-sm">
               <span>Faltan: Gs. {remaining.toLocaleString('es-PY')}</span>
               <span>{percentage}% {isComplete && '🎉'}</span>
             </div>
@@ -93,21 +100,21 @@ export default function GuestGiftCard({
 
       {wishlistGift.isGroupGift ? (
         <Button
-          className={`gap-2 justify-between bg-gray-100 hover:bg-gray-200 transition-colors ${isComplete ? 'bg-success/10 text-success' : ''}`}
+          className={`gap-1 justify-between text-xs bg-gray-100 hover:bg-gray-200 transition-colors sm:gap-2 sm:text-sm ${isComplete ? 'bg-success/10 text-success' : ''}`}
           onClick={() => onOpenContributionDialog(wishlistGift)}
           disabled={isComplete}
         >
           {isComplete ? 'Regalo recibido' : 'Seleccionar monto'}
-          <IoChevronForward className="text-lg" />
+          <IoChevronForward className="text-lg shrink-0" />
         </Button>
       ) : (
         <Button
-          className={`gap-2 justify-between bg-gray-100 hover:bg-gray-200 transition-colors ${isComplete ? 'bg-success/10 text-success' : ''}`}
+          className={`gap-1 justify-between text-xs bg-gray-100 hover:bg-gray-200 transition-colors sm:gap-2 sm:text-sm ${isComplete ? 'bg-success/10 text-success' : ''}`}
           onClick={() => onAddFullPrice(wishlistGift)}
           disabled={isComplete}
         >
           {isComplete ? 'Regalo recibido' : 'Agregar al carrito'}
-          <IoCartOutline className="text-lg" />
+          <IoCartOutline className="text-lg shrink-0" />
         </Button>
       )}
     </div>

--- a/components/guest/guest-gift-catalog.tsx
+++ b/components/guest/guest-gift-catalog.tsx
@@ -5,7 +5,7 @@ import { IoGiftOutline, IoPeopleOutline, IoPersonOutline, IoSearchOutline } from
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 import { useStore } from '@/hooks/use-store';
-import { useCartStore } from '@/hooks/use-cart-store';
+import { useCartStore, type CartItem } from '@/hooks/use-cart-store';
 import GuestGiftCard, {
   type WishlistGiftWithGift,
 } from '@/components/guest/guest-gift-card';
@@ -46,6 +46,9 @@ export default function GuestGiftCatalog({
   const [isCartOpen, setIsCartOpen] = useState(false);
   const [selectedWishlistGift, setSelectedWishlistGift] =
     useState<WishlistGiftWithGift | null>(null);
+  const [editingCartItem, setEditingCartItem] = useState<CartItem | null>(
+    null
+  );
 
   const cartTotal = cartItems.reduce(
     (sum, item) => sum + (Number(item.amount) || 0),
@@ -57,6 +60,7 @@ export default function GuestGiftCatalog({
       wishlistGiftId: wishlistGift.id,
       giftName: wishlistGift.gift.name,
       giftImageUrl: wishlistGift.gift.image?.url ?? null,
+      isGroupGift: wishlistGift.isGroupGift,
       amount,
     });
     toast({
@@ -75,8 +79,40 @@ export default function GuestGiftCatalog({
     setSelectedWishlistGift(wishlistGift);
   };
 
+  const handleEditCartItem = (item: CartItem) => {
+    const wishlistGift = wishlistGifts.find(
+      candidate => candidate.id === item.wishlistGiftId
+    );
+    if (!wishlistGift) return;
+
+    setEditingCartItem(item);
+    setSelectedWishlistGift(wishlistGift);
+    setIsCartOpen(false);
+  };
+
   const handleContributionSubmit = (amount: string) => {
-    if (selectedWishlistGift) addToCart(selectedWishlistGift, amount);
+    if (!selectedWishlistGift) return;
+
+    if (editingCartItem) {
+      cartStore.getState().updateItemAmount(editingCartItem.id, amount);
+    } else {
+      addToCart(selectedWishlistGift, amount);
+    }
+  };
+
+  const handleContributionDialogOpenChange = (open: boolean) => {
+    if (open) return;
+
+    setSelectedWishlistGift(null);
+    if (editingCartItem) {
+      setEditingCartItem(null);
+      setIsCartOpen(true);
+    }
+  };
+
+  const handleRemoveCartItem = (id: string) => {
+    cartStore.getState().removeItem(id);
+    if (cartItems.length === 1) setIsCartOpen(false);
   };
 
   const filteredWishlistGifts = wishlistGifts
@@ -111,7 +147,7 @@ export default function GuestGiftCatalog({
     <section
       id="lista-de-regalos"
       className={`px-4 py-8 sm:py-12 mx-auto max-w-7xl sm:px-6 lg:px-8 ${
-        cartItems.length > 0 ? 'mb-20 sm:mb-10' : ''
+        cartItems.length > 0 ? 'mb-12 sm:mb-10' : ''
       }`}
     >
       <h2 className="mb-6 text-3xl font-medium">Lista de regalos</h2>
@@ -175,7 +211,7 @@ export default function GuestGiftCatalog({
           No se encontraron regalos
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3">
           {filteredWishlistGifts.map(wishlistGift => (
             <GuestGiftCard
               key={wishlistGift.id}
@@ -190,14 +226,13 @@ export default function GuestGiftCatalog({
       {selectedWishlistGift && selectedProgress && (
         <GiftContributionDialog
           open={!!selectedWishlistGift}
-          onOpenChange={open => {
-            if (!open) setSelectedWishlistGift(null);
-          }}
+          onOpenChange={handleContributionDialogOpenChange}
           gift={selectedWishlistGift.gift}
           isFavoriteGift={selectedWishlistGift.isFavoriteGift}
           remaining={selectedProgress.remaining}
           percentage={selectedProgress.percentage}
           onAddToCart={handleContributionSubmit}
+          initialAmount={editingCartItem?.amount}
         />
       )}
 
@@ -211,10 +246,8 @@ export default function GuestGiftCatalog({
         onOpenChange={setIsCartOpen}
         items={cartItems}
         total={cartTotal}
-        onRemoveItem={id => {
-          cartStore.getState().removeItem(id);
-          if (cartItems.length === 1) setIsCartOpen(false);
-        }}
+        onRemoveItem={handleRemoveCartItem}
+        onEditItem={handleEditCartItem}
       />
     </section>
   );

--- a/components/guest/guest-hero.tsx
+++ b/components/guest/guest-hero.tsx
@@ -26,7 +26,7 @@ export default function GuestHero({ event }: GuestHeroProps) {
 
   return (
     <div className="bg-gray-50">
-      <section className="grid grid-cols-1 gap-8 items-center px-4 py-8 sm:py-12 mx-auto max-w-7xl sm:px-6 lg:px-8 lg:grid-cols-2">
+      <section className="grid grid-cols-1 gap-6 sm:gap-8 items-center px-4 py-8 sm:py-12 mx-auto max-w-7xl sm:px-6 lg:px-8 lg:grid-cols-2">
         <div className="w-full aspect-[3/4]">
           <GuestImageCarousel images={event.images} />
         </div>

--- a/hooks/use-cart-store.ts
+++ b/hooks/use-cart-store.ts
@@ -7,12 +7,14 @@ export type CartItem = {
   giftName: string;
   giftImageUrl: string | null;
   amount: string;
+  isGroupGift: boolean;
 };
 
 type CartState = {
   items: CartItem[];
   addItem: (item: Omit<CartItem, 'id'>) => void;
   removeItem: (id: string) => void;
+  updateItemAmount: (id: string, amount: string) => void;
   clear: () => void;
 };
 
@@ -36,6 +38,12 @@ function createCartStore(eventId: string): CartStore {
         removeItem: id =>
           set(state => ({
             items: state.items.filter(item => item.id !== id),
+          })),
+        updateItemAmount: (id, amount) =>
+          set(state => ({
+            items: state.items.map(item =>
+              item.id === id ? { ...item, amount } : item
+            ),
           })),
         clear: () => set({ items: [] }),
       }),


### PR DESCRIPTION
- Cart drawer: split footer into Cancelar/Ir a pagar buttons (30/70), give the dialog a consistent min-height, and make group-gift line items editable (pencil opens the contribution dialog pre-filled, updates the cart item instead of adding a duplicate)
- Guest gift grid: 2 columns on mobile, with the card compacted at that width (clamped title, stacked progress row, smaller badges, short "Favorito" label) instead of overflowing/wrapping inconsistently between cards
- Cart sticky bar: compact single-line layout on mobile (cart icon with item-count badge + subtotal + CTA) instead of the two-stat block that wrapped awkwardly at narrow widths